### PR TITLE
Add additional Claude Code permissions to settings.local.json

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -4,7 +4,11 @@
       "Bash(git add:*)",
       "Bash(git commit:*)",
       "Bash(git push:*)",
-      "Bash(bunx playwright:*)"
+      "Bash(bunx playwright:*)",
+      "WebFetch(domain:spring.io)",
+      "WebFetch(domain:github.com)",
+      "Bash(./gradlew test:*)",
+      "Bash(git fetch:*)"
     ]
   }
 }


### PR DESCRIPTION
Allow WebFetch for spring.io and github.com, ./gradlew test, and git fetch without requiring manual approval each time.