### PR TITLE
Add frontend Dockerfile and docker-compose service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,3 +24,12 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+
+  frontend:
+    build: ./frontend
+    ports:
+      - "3000:3000"
+    environment:
+      ORIGIN: http://localhost:3000
+    depends_on:
+      - backend

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,14 @@
+FROM oven/bun:1 AS build
+WORKDIR /app
+COPY package.json bun.lockb ./
+RUN bun install --frozen-lockfile
+COPY . .
+RUN bun run build
+
+FROM node:22-alpine AS runtime
+WORKDIR /app
+COPY --from=build /app/build ./build
+COPY --from=build /app/node_modules ./node_modules
+EXPOSE 3000
+ENV NODE_ENV=production
+CMD ["node", "build/index.js"]


### PR DESCRIPTION
Multi-stage build using bun for deps/build and node:22-alpine for the runtime stage. Adds frontend service to docker-compose.yml with ORIGIN env var for SvelteKit CSRF protection.