### PR TITLE
fix: accept standard base64 JWT secret

### DIFF
--- a/backend/src/main/kotlin/com/github/matthiasbalke/todo/auth/JwtTokenService.kt
+++ b/backend/src/main/kotlin/com/github/matthiasbalke/todo/auth/JwtTokenService.kt
@@ -16,7 +16,7 @@ import java.util.UUID
 class JwtTokenService(private val jwtProperties: JwtProperties) {
 
     private val signingKey by lazy {
-        Keys.hmacShaKeyFor(Decoders.BASE64URL.decode(jwtProperties.secret))
+        Keys.hmacShaKeyFor(Decoders.BASE64.decode(jwtProperties.secret))
     }
 
     fun generateAccessToken(user: User): String {


### PR DESCRIPTION
## Summary

- Switches JWT secret decoder from `BASE64URL` to `BASE64` in `JwtTokenService`
- Fixes a `DecodingException` caused by `+` and `/` characters in secrets generated with `openssl rand -base64 32`

## Test plan

- [ ] Generate a secret with `openssl rand -base64 32` and set it as `JWT_SECRET`
- [ ] Start the backend and verify no `DecodingException` on token operations
- [ ] Confirm login, token generation, and token validation still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)