### PR TITLE
feat: startup indicator — poll /actuator/health before showing auth UI

### DIFF
--- a/all-in-one/nginx.conf
+++ b/all-in-one/nginx.conf
@@ -12,6 +12,14 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
         }
 
+        location /actuator/ {
+            proxy_pass http://localhost:8080;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
         location / {
             proxy_pass http://localhost:3000;
             proxy_set_header Host $host;

--- a/docker-compose.remote.yml
+++ b/docker-compose.remote.yml
@@ -1,0 +1,42 @@
+services:
+  postgres:
+    image: postgres:17
+    environment:
+      POSTGRES_DB: todo
+      POSTGRES_USER: todo
+      POSTGRES_PASSWORD: todo
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U todo -d todo"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  backend:
+    image: ghcr.io/matthiasbalke/todo/backend:main
+    ports:
+      - "8080:8080"
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/todo
+      SPRING_DATASOURCE_USERNAME: todo
+      SPRING_DATASOURCE_PASSWORD: todo
+      JWT_SECRET: ZGV2LXNlY3JldC1rZXktZm9yLWxvY2FsLWRldmVsb3BtZW50
+    depends_on:
+      postgres:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:8080/actuator/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 30s
+
+  frontend:
+    image: ghcr.io/matthiasbalke/todo/frontend:main
+    ports:
+      - "3000:3000"
+    environment:
+      ORIGIN: http://localhost:3000
+    depends_on:
+      - backend

--- a/docs/features/startup-indicator.md
+++ b/docs/features/startup-indicator.md
@@ -1,0 +1,41 @@
+# Feature: Backend Startup Indicator
+
+## Problem
+
+The SvelteKit frontend starts significantly faster than the Spring Boot backend (Flyway migrations add further delay). Users navigating to `/auth` before the backend is ready see a login form that immediately fails on any interaction.
+
+## Solution
+
+Poll `/actuator/health` from the auth page before rendering the login form. Show a loading spinner while waiting, and transition to the login form once the backend reports healthy.
+
+## State Machine
+
+```
+'starting'  (initial)
+   │  checkHealth() returns true (within 60 retries × 2s = 2 min)
+   ▼
+   getAuthConfig() → mode = 'idle'  (login form shown)
+   │  60 retries exhausted
+   ▼
+'startup-timeout'  (terminal — user must reload)
+```
+
+## Implementation
+
+- **`frontend/src/lib/api/health.ts`** — `checkHealth()` fetches `/actuator/health`, returns `true` on HTTP 200, `false` on any other status or network error.
+- **`frontend/src/lib/api/health.test.ts`** — unit tests for the three cases: 200, 503, network error.
+- **`frontend/src/routes/auth/+page.svelte`** — starts in `'starting'` mode, polls every 2 s, transitions to `'idle'` after health passes and config is fetched, or to `'startup-timeout'` after 60 failed retries.
+
+## Security
+
+`/actuator/health` is already public (`show-details: never`) and returns only `{"status":"UP"}`. No new endpoints are added.
+
+## Edge Cases
+
+| Scenario | Behaviour |
+|---|---|
+| Backend returns non-200 during poll | Poll continues, retry counter increments |
+| Network error during poll | Poll continues, retry counter increments |
+| 60 retries exhausted | `startup-timeout` shown, no auto-retry |
+| Backend already up on first poll | `starting` visible for ≤ 2 s |
+| `getAuthConfig` fails after health passes | Silently ignored; `registrationEnabled` stays `true` |

--- a/frontend/src/lib/api/health.test.ts
+++ b/frontend/src/lib/api/health.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { checkHealth } from './health';
+
+describe('health API client', () => {
+	let fetchSpy: ReturnType<typeof vi.fn>;
+
+	beforeEach(() => {
+		fetchSpy = vi.fn();
+		vi.stubGlobal('fetch', fetchSpy);
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('returns true on status 200', async () => {
+		fetchSpy.mockResolvedValue({ status: 200 } as Response);
+
+		const result = await checkHealth();
+
+		expect(result).toBe(true);
+	});
+
+	it('returns false on status 503', async () => {
+		fetchSpy.mockResolvedValue({ status: 503 } as Response);
+
+		const result = await checkHealth();
+
+		expect(result).toBe(false);
+	});
+
+	it('returns false when fetch rejects (network error)', async () => {
+		fetchSpy.mockRejectedValue(new Error('Network error'));
+
+		const result = await checkHealth();
+
+		expect(result).toBe(false);
+	});
+});

--- a/frontend/src/lib/api/health.ts
+++ b/frontend/src/lib/api/health.ts
@@ -1,0 +1,8 @@
+export async function checkHealth(): Promise<boolean> {
+	try {
+		const response = await fetch('/actuator/health');
+		return response.status === 200;
+	} catch {
+		return false;
+	}
+}

--- a/frontend/src/routes/auth/+page.svelte
+++ b/frontend/src/routes/auth/+page.svelte
@@ -1,23 +1,50 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
+  import { onDestroy, onMount } from 'svelte';
   import { goto } from '$app/navigation';
   import { ApiError, getAuthConfig, loginWithPasskey, registerWithPasskey } from '$lib/api/auth';
+  import { checkHealth } from '$lib/api/health';
   import { setSession } from '$lib/stores/auth.svelte';
 
-  type Mode = 'idle' | 'register-form' | 'signing-in' | 'registering' | 'error';
+  type Mode = 'starting' | 'idle' | 'register-form' | 'signing-in' | 'registering' | 'error' | 'startup-timeout';
 
-  let mode = $state<Mode>('idle');
+  let mode = $state<Mode>('starting');
   let errorMessage = $state('');
   let email = $state('');
   let displayName = $state('');
   let registrationEnabled = $state(true);
 
+  let pollInterval: ReturnType<typeof setInterval> | undefined;
+
   onMount(async () => {
-    try {
-      const config = await getAuthConfig();
-      registrationEnabled = config.registrationEnabled;
-    } catch {
-      // default to true if config fetch fails — backend will enforce the real value
+    let retries = 0;
+    const maxRetries = 60;
+
+    pollInterval = setInterval(async () => {
+      const healthy = await checkHealth();
+      if (healthy) {
+        clearInterval(pollInterval);
+        pollInterval = undefined;
+        try {
+          const config = await getAuthConfig();
+          registrationEnabled = config.registrationEnabled;
+        } catch {
+          // default to true if config fetch fails — backend will enforce the real value
+        }
+        mode = 'idle';
+      } else {
+        retries++;
+        if (retries >= maxRetries) {
+          clearInterval(pollInterval);
+          pollInterval = undefined;
+          mode = 'startup-timeout';
+        }
+      }
+    }, 2000);
+  });
+
+  onDestroy(() => {
+    if (pollInterval !== undefined) {
+      clearInterval(pollInterval);
     }
   });
 
@@ -70,99 +97,114 @@
 </script>
 
 <div class="min-h-screen bg-gray-50 flex items-center justify-center p-4">
-  <div class="w-full max-w-sm bg-white rounded-2xl shadow-sm border border-gray-100 p-8">
-    <h1 class="text-2xl font-bold text-gray-900 mb-2">Welcome</h1>
-    <p class="text-gray-500 text-sm mb-6">{registrationEnabled ? 'Sign in or create an account' : 'Sign in'}</p>
+  {#if mode === 'starting'}
+    <div class="w-full max-w-sm bg-white rounded-2xl shadow-sm border border-gray-100 p-8 flex flex-col items-center gap-4">
+      <svg class="animate-spin h-8 w-8 text-blue-600" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+        <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>
+      </svg>
+      <p class="text-gray-500 text-sm">Application is starting…</p>
+    </div>
+  {:else if mode === 'startup-timeout'}
+    <div class="w-full max-w-sm bg-white rounded-2xl shadow-sm border border-gray-100 p-8">
+      <h1 class="text-2xl font-bold text-gray-900 mb-2">Unavailable</h1>
+      <p class="text-gray-500 text-sm">Backend did not respond. Please try reloading.</p>
+    </div>
+  {:else}
+    <div class="w-full max-w-sm bg-white rounded-2xl shadow-sm border border-gray-100 p-8">
+      <h1 class="text-2xl font-bold text-gray-900 mb-2">Welcome</h1>
+      <p class="text-gray-500 text-sm mb-6">{registrationEnabled ? 'Sign in or create an account' : 'Sign in'}</p>
 
-    {#if errorMessage}
-      <div class="mb-4 p-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-700">
-        {errorMessage}
-      </div>
-    {/if}
-
-    {#if mode === 'register-form' || mode === 'registering' || mode === 'error'}
-      <form onsubmit={handleRegister} class="space-y-4">
-        <div>
-          <label class="text-sm font-medium text-gray-700 mb-1 block" for="displayName">
-            Display name
-          </label>
-          <input
-            id="displayName"
-            type="text"
-            bind:value={displayName}
-            placeholder="Your name"
-            required
-            class="w-full border border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-          />
+      {#if errorMessage}
+        <div class="mb-4 p-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-700">
+          {errorMessage}
         </div>
-        <div>
-          <label class="text-sm font-medium text-gray-700 mb-1 block" for="email">Email</label>
-          <input
-            id="email"
-            type="email"
-            bind:value={email}
-            placeholder="you@example.com"
-            required
-            class="w-full border border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-          />
-        </div>
+      {/if}
 
-        <button
-          type="submit"
-          disabled={mode === 'registering'}
-          class="w-full bg-blue-600 text-white rounded-lg py-2.5 text-sm font-medium hover:bg-blue-700 transition-colors flex items-center justify-center gap-2 disabled:opacity-50"
-        >
-          {#if mode === 'registering'}
-            <span>Creating account…</span>
-          {:else}
-            <span>🔑</span>
-            <span>Register passkey</span>
-          {/if}
-        </button>
-
-        <button
-          type="button"
-          onclick={resetToIdle}
-          class="w-full text-sm text-gray-500 hover:text-gray-700 py-1"
-        >
-          Back
-        </button>
-      </form>
-    {:else}
-      <div class="space-y-3">
-        <button
-          type="button"
-          onclick={handleSignIn}
-          disabled={mode === 'signing-in'}
-          class="w-full bg-blue-600 text-white rounded-lg py-2.5 text-sm font-medium hover:bg-blue-700 transition-colors flex items-center justify-center gap-2 disabled:opacity-50"
-        >
-          {#if mode === 'signing-in'}
-            <span>Waiting for passkey…</span>
-          {:else}
-            <span>🔑</span>
-            <span>Sign in with Passkey</span>
-          {/if}
-        </button>
-
-        {#if registrationEnabled}
-          <div class="relative my-4">
-            <div class="absolute inset-0 flex items-center">
-              <div class="w-full border-t border-gray-200"></div>
-            </div>
-            <div class="relative flex justify-center text-xs text-gray-400">
-              <span class="bg-white px-2">or</span>
-            </div>
+      {#if mode === 'register-form' || mode === 'registering' || mode === 'error'}
+        <form onsubmit={handleRegister} class="space-y-4">
+          <div>
+            <label class="text-sm font-medium text-gray-700 mb-1 block" for="displayName">
+              Display name
+            </label>
+            <input
+              id="displayName"
+              type="text"
+              bind:value={displayName}
+              placeholder="Your name"
+              required
+              class="w-full border border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+          <div>
+            <label class="text-sm font-medium text-gray-700 mb-1 block" for="email">Email</label>
+            <input
+              id="email"
+              type="email"
+              bind:value={email}
+              placeholder="you@example.com"
+              required
+              class="w-full border border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
           </div>
 
           <button
-            type="button"
-            onclick={showRegisterForm}
-            class="w-full border border-gray-200 text-gray-700 rounded-lg py-2.5 text-sm font-medium hover:bg-gray-50 transition-colors"
+            type="submit"
+            disabled={mode === 'registering'}
+            class="w-full bg-blue-600 text-white rounded-lg py-2.5 text-sm font-medium hover:bg-blue-700 transition-colors flex items-center justify-center gap-2 disabled:opacity-50"
           >
-            Create account
+            {#if mode === 'registering'}
+              <span>Creating account…</span>
+            {:else}
+              <span>🔑</span>
+              <span>Register passkey</span>
+            {/if}
           </button>
-        {/if}
-      </div>
-    {/if}
-  </div>
+
+          <button
+            type="button"
+            onclick={resetToIdle}
+            class="w-full text-sm text-gray-500 hover:text-gray-700 py-1"
+          >
+            Back
+          </button>
+        </form>
+      {:else}
+        <div class="space-y-3">
+          <button
+            type="button"
+            onclick={handleSignIn}
+            disabled={mode === 'signing-in'}
+            class="w-full bg-blue-600 text-white rounded-lg py-2.5 text-sm font-medium hover:bg-blue-700 transition-colors flex items-center justify-center gap-2 disabled:opacity-50"
+          >
+            {#if mode === 'signing-in'}
+              <span>Waiting for passkey…</span>
+            {:else}
+              <span>🔑</span>
+              <span>Sign in with Passkey</span>
+            {/if}
+          </button>
+
+          {#if registrationEnabled}
+            <div class="relative my-4">
+              <div class="absolute inset-0 flex items-center">
+                <div class="w-full border-t border-gray-200"></div>
+              </div>
+              <div class="relative flex justify-center text-xs text-gray-400">
+                <span class="bg-white px-2">or</span>
+              </div>
+            </div>
+
+            <button
+              type="button"
+              onclick={showRegisterForm}
+              class="w-full border border-gray-200 text-gray-700 rounded-lg py-2.5 text-sm font-medium hover:bg-gray-50 transition-colors"
+            >
+              Create account
+            </button>
+          {/if}
+        </div>
+      {/if}
+    </div>
+  {/if}
 </div>

--- a/frontend/src/routes/auth/auth-page.test.ts
+++ b/frontend/src/routes/auth/auth-page.test.ts
@@ -18,6 +18,7 @@ vi.mock('$lib/stores/auth.svelte', () => ({
 vi.mock('$lib/api/auth', () => ({
 	loginWithPasskey: vi.fn(),
 	registerWithPasskey: vi.fn(),
+	getAuthConfig: vi.fn().mockResolvedValue({ registrationEnabled: true }),
 	ApiError: class ApiError extends Error {
 		constructor(public status: number, message: string) {
 			super(message);
@@ -25,31 +26,48 @@ vi.mock('$lib/api/auth', () => ({
 	},
 }));
 
+// Mock the health API — backend is healthy by default
+vi.mock('$lib/api/health', () => ({
+	checkHealth: vi.fn().mockResolvedValue(true),
+}));
+
 import { goto } from '$app/navigation';
 import * as authApi from '$lib/api/auth';
 import { setSession } from '$lib/stores/auth.svelte';
 import AuthPage from './+page.svelte';
 
+async function waitForIdle() {
+	await vi.advanceTimersByTimeAsync(2100);
+}
+
 describe('AuthPage', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
 	afterEach(() => {
+		vi.useRealTimers();
 		cleanup();
 		vi.clearAllMocks();
 	});
 
-	it('renders Sign in with Passkey and Create account buttons', () => {
+	it('renders Sign in with Passkey and Create account buttons', async () => {
 		render(AuthPage);
+		await waitForIdle();
 		expect(screen.getByRole('button', { name: /sign in with passkey/i })).toBeInTheDocument();
 		expect(screen.getByRole('button', { name: /create account/i })).toBeInTheDocument();
 	});
 
-	it('does not show registration form by default', () => {
+	it('does not show registration form by default', async () => {
 		render(AuthPage);
+		await waitForIdle();
 		expect(screen.queryByLabelText(/email/i)).not.toBeInTheDocument();
 		expect(screen.queryByLabelText(/display name/i)).not.toBeInTheDocument();
 	});
 
 	it('shows registration form when Create account is clicked', async () => {
 		render(AuthPage);
+		await waitForIdle();
 		await fireEvent.click(screen.getByRole('button', { name: /create account/i }));
 		expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
 		expect(screen.getByLabelText(/display name/i)).toBeInTheDocument();
@@ -60,6 +78,7 @@ describe('AuthPage', () => {
 		vi.mocked(authApi.loginWithPasskey).mockResolvedValue(mockResult);
 
 		render(AuthPage);
+		await waitForIdle();
 		await fireEvent.click(screen.getByRole('button', { name: /sign in with passkey/i }));
 
 		await waitFor(() => {
@@ -73,6 +92,7 @@ describe('AuthPage', () => {
 		vi.mocked(authApi.loginWithPasskey).mockRejectedValue(error);
 
 		render(AuthPage);
+		await waitForIdle();
 		await fireEvent.click(screen.getByRole('button', { name: /sign in with passkey/i }));
 
 		await waitFor(() => {
@@ -86,6 +106,7 @@ describe('AuthPage', () => {
 		vi.mocked(authApi.loginWithPasskey).mockRejectedValue(error);
 
 		render(AuthPage);
+		await waitForIdle();
 		await fireEvent.click(screen.getByRole('button', { name: /sign in with passkey/i }));
 
 		await waitFor(() => {
@@ -99,6 +120,7 @@ describe('AuthPage', () => {
 		vi.mocked(authApi.loginWithPasskey).mockRejectedValue(error);
 
 		render(AuthPage);
+		await waitForIdle();
 		await fireEvent.click(screen.getByRole('button', { name: /sign in with passkey/i }));
 
 		await waitFor(() => {
@@ -113,6 +135,7 @@ describe('AuthPage', () => {
 		vi.mocked(authApi.registerWithPasskey).mockResolvedValue(mockResult);
 
 		render(AuthPage);
+		await waitForIdle();
 		await fireEvent.click(screen.getByRole('button', { name: /create account/i }));
 
 		await fireEvent.input(screen.getByLabelText(/display name/i), {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -14,6 +14,10 @@ export default defineConfig({
           });
         },
       },
+      '/actuator': {
+        target: 'http://localhost:8080',
+        changeOrigin: true,
+      },
     },
   },
   plugins: [


### PR DESCRIPTION
## Summary

- Shows a spinner on the `/auth` page while the backend is starting up, then transitions to the login UI once `/actuator/health` returns healthy
- Adds `checkHealth()` API function polling every 2 s (max 60 retries / 2 min) with a timeout fallback state
- Fixes the all-in-one nginx config to proxy `/actuator/` to the backend (port 8080) — previously the catch-all `location /` was forwarding health checks to the frontend
- Forwards `/actuator` in the Vite dev proxy for consistent local development behaviour

## Test plan

- [ ] Unit tests updated: health API mock injected, fake timers advance past the poll interval before asserting UI state
- [ ] Build and run the all-in-one image; `curl http://localhost/actuator/health` returns Spring Boot health JSON
- [ ] Navigate to `/auth` — spinner shown during startup, disappears once backend is healthy
- [ ] Let the poll time out (stop the backend) — "Unavailable" message shown after ~2 min

🤖 Generated with [Claude Code](https://claude.com/claude-code)