### PR TITLE
feat: embed build version into backend jar and frontend bundle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,25 @@ on:
     branches: [main]
 
 jobs:
+  compute-version:
+    name: Compute version
+    runs-on: ubuntu-latest
+    outputs:
+      backend-version: ${{ steps.version.outputs.backend }}
+      frontend-version: ${{ steps.version.outputs.frontend }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Extract versions
+        id: version
+        run: |
+          BACKEND_BASE=$(grep '^version = ' backend/build.gradle.kts \
+            | sed 's/version = "\(.*\)-SNAPSHOT"/\1/')
+          FRONTEND_BASE=$(node -p "require('./frontend/package.json').version")
+          echo "backend=${BACKEND_BASE}.${{ github.run_number }}" >> $GITHUB_OUTPUT
+          echo "frontend=${FRONTEND_BASE}.${{ github.run_number }}" >> $GITHUB_OUTPUT
+
   backend:
+    needs: [compute-version]
     name: Backend
     runs-on: ubuntu-latest
     steps:
@@ -20,7 +38,7 @@ jobs:
           cache: gradle
 
       - name: Build and test
-        run: ./gradlew build test
+        run: ./gradlew build test -Pversion=${{ needs.compute-version.outputs.backend-version }}
         working-directory: backend
 
       - name: Upload test report
@@ -31,6 +49,7 @@ jobs:
           path: backend/build/reports/tests/
 
   frontend:
+    needs: [compute-version]
     name: Frontend
     runs-on: ubuntu-latest
     steps:
@@ -39,6 +58,12 @@ jobs:
       - uses: oven-sh/setup-bun@v2
 
       - run: bun install --frozen-lockfile
+        working-directory: frontend
+
+      - name: Set version
+        run: |
+          jq --arg v "${{ needs.compute-version.outputs.frontend-version }}" '.version = $v' package.json > /tmp/pkg.json
+          mv /tmp/pkg.json package.json
         working-directory: frontend
 
       - name: Type check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,25 @@ on:
     tags: ['v*']
 
 jobs:
+  compute-version:
+    name: Compute version
+    runs-on: ubuntu-latest
+    outputs:
+      backend-version: ${{ steps.version.outputs.backend }}
+      frontend-version: ${{ steps.version.outputs.frontend }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Extract versions
+        id: version
+        run: |
+          BACKEND_BASE=$(grep '^version = ' backend/build.gradle.kts \
+            | sed 's/version = "\(.*\)-SNAPSHOT"/\1/')
+          FRONTEND_BASE=$(node -p "require('./frontend/package.json').version")
+          echo "backend=${BACKEND_BASE}.${{ github.run_number }}" >> $GITHUB_OUTPUT
+          echo "frontend=${FRONTEND_BASE}.${{ github.run_number }}" >> $GITHUB_OUTPUT
+
   build-backend:
+    needs: [compute-version]
     name: Build backend image
     uses: docker/github-builder/.github/workflows/build.yml@v1
     permissions:
@@ -19,6 +37,7 @@ jobs:
       platforms: linux/amd64,linux/arm64
       context: backend
       cache: true
+      build-args: APP_VERSION=${{ needs.compute-version.outputs.backend-version }}
       meta-images: ghcr.io/${{ github.repository }}/backend
       meta-tags: |
         type=ref,event=branch
@@ -32,6 +51,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
   build-frontend:
+    needs: [compute-version]
     name: Build frontend image
     uses: docker/github-builder/.github/workflows/build.yml@v1
     permissions:
@@ -44,6 +64,7 @@ jobs:
       platforms: linux/amd64,linux/arm64
       context: frontend
       cache: true
+      build-args: APP_VERSION=${{ needs.compute-version.outputs.frontend-version }}
       meta-images: ghcr.io/${{ github.repository }}/frontend
       meta-tags: |
         type=ref,event=branch
@@ -57,6 +78,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
   build-all-in-one:
+    needs: [compute-version]
     name: Build all-in-one image
     uses: docker/github-builder/.github/workflows/build.yml@v1
     permissions:
@@ -70,6 +92,7 @@ jobs:
       context: .
       file: all-in-one/Dockerfile
       cache: true
+      build-args: APP_VERSION=${{ needs.compute-version.outputs.backend-version }}
       meta-images: ghcr.io/${{ github.repository }}/all-in-one
       meta-tags: |
         type=ref,event=branch

--- a/all-in-one/Dockerfile
+++ b/all-in-one/Dockerfile
@@ -1,15 +1,22 @@
+ARG APP_VERSION=0.1.0-SNAPSHOT
+
 # Stage 1: build backend
 FROM gradle:8-jdk21 AS backend-build
+ARG APP_VERSION
 WORKDIR /app
 COPY backend/ .
-RUN ./gradlew bootJar --no-daemon
+RUN ./gradlew bootJar --no-daemon -Pversion=${APP_VERSION}
 
 # Stage 2: build frontend
 FROM oven/bun:1 AS frontend-build
+ARG APP_VERSION
 WORKDIR /app
 COPY frontend/package.json frontend/bun.lockb ./
 RUN bun install --frozen-lockfile
 COPY frontend/ .
+RUN apt-get update && apt-get install -y --no-install-recommends jq \
+    && jq --arg v "${APP_VERSION}" '.version = $v' package.json > /tmp/pkg.json \
+    && mv /tmp/pkg.json package.json
 RUN bun run build
 
 # Stage 3: runtime

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,7 +1,8 @@
 FROM gradle:8-jdk21 AS build
 WORKDIR /app
 COPY . .
-RUN ./gradlew bootJar --no-daemon
+ARG APP_VERSION=0.1.0-SNAPSHOT
+RUN ./gradlew bootJar --no-daemon -Pversion=${APP_VERSION}
 
 FROM eclipse-temurin:21-jre-alpine
 WORKDIR /app

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -9,6 +9,10 @@ plugins {
 group = "com.github.matthiasbalke"
 version = "0.1.0-SNAPSHOT"
 
+springBoot {
+	buildInfo()
+}
+
 java {
 	toolchain {
 		languageVersion = JavaLanguageVersion.of(21)

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -33,6 +33,9 @@ app:
       capacity: 50
 
 management:
+  info:
+    build:
+      enabled: true
   endpoints:
     web:
       exposure:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -3,6 +3,10 @@ WORKDIR /app
 COPY package.json bun.lockb ./
 RUN bun install --frozen-lockfile
 COPY . .
+ARG APP_VERSION=0.0.1
+RUN apt-get update && apt-get install -y --no-install-recommends jq \
+    && jq --arg v "${APP_VERSION}" '.version = $v' package.json > /tmp/pkg.json \
+    && mv /tmp/pkg.json package.json
 RUN bun run build
 
 FROM node:24-alpine AS runtime

--- a/frontend/src/lib/api/health.ts
+++ b/frontend/src/lib/api/health.ts
@@ -6,3 +6,14 @@ export async function checkHealth(): Promise<boolean> {
 		return false;
 	}
 }
+
+export async function getBackendVersion(): Promise<string | null> {
+	try {
+		const response = await fetch('/actuator/info');
+		if (!response.ok) return null;
+		const data = await response.json();
+		return (data.build?.version as string) ?? null;
+	} catch {
+		return null;
+	}
+}

--- a/frontend/src/lib/version.ts
+++ b/frontend/src/lib/version.ts
@@ -1,0 +1,2 @@
+declare const __APP_VERSION__: string;
+export const appVersion: string = __APP_VERSION__;

--- a/frontend/src/routes/(app)/+layout.svelte
+++ b/frontend/src/routes/(app)/+layout.svelte
@@ -17,7 +17,7 @@
   }
 </script>
 
-<div class="min-h-screen bg-gray-50">
+<div>
   <header class="bg-white border-b border-gray-100 sticky top-0 z-10">
     <div class="max-w-2xl mx-auto px-4 h-14 flex items-center justify-between">
       <a href="/lists" class="text-lg font-bold text-gray-900">Todo</a>

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -1,7 +1,31 @@
 <script lang="ts">
   import '../app.css';
   import { onMount } from 'svelte';
+  import { appVersion } from '$lib/version';
+  import { getBackendVersion } from '$lib/api/health';
+
   let { children } = $props();
-  onMount(() => { document.body.dataset.hydrated = 'true'; });
+
+  let backendVersion = $state<string | null>(null);
+  let fetchDone = $state(false);
+
+  onMount(async () => {
+    document.body.dataset.hydrated = 'true';
+    backendVersion = await getBackendVersion();
+    fetchDone = true;
+  });
 </script>
-{@render children()}
+
+<div class="min-h-screen bg-gray-50 flex flex-col">
+  <div class="flex-1 flex flex-col">
+    {@render children()}
+  </div>
+  <footer class="py-4 text-center text-xs text-gray-400">
+    frontend v{appVersion}
+    {#if backendVersion}
+      · backend v{backendVersion}
+    {:else if !fetchDone}
+      · backend …
+    {/if}
+  </footer>
+</div>

--- a/frontend/src/routes/auth/+page.svelte
+++ b/frontend/src/routes/auth/+page.svelte
@@ -96,7 +96,7 @@
   }
 </script>
 
-<div class="min-h-screen bg-gray-50 flex items-center justify-center p-4">
+<div class="flex-1 flex items-center justify-center p-4">
   {#if mode === 'starting'}
     <div class="w-full max-w-sm bg-white rounded-2xl shadow-sm border border-gray-100 p-8 flex flex-col items-center gap-4">
       <svg class="animate-spin h-8 w-8 text-blue-600" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -3,6 +3,9 @@ import tailwindcss from '@tailwindcss/vite';
 import { SvelteKitPWA } from '@vite-pwa/sveltekit';
 import { defineConfig } from 'vite';
 export default defineConfig({
+  define: {
+    __APP_VERSION__: JSON.stringify(process.env.npm_package_version ?? '0.0.0-dev'),
+  },
   server: {
     proxy: {
       '/api': {


### PR DESCRIPTION
## Summary

- Adds a `compute-version` job to both `ci.yml` and `release.yml` that extracts base versions from source and appends the GitHub Actions run number as a four-part semver (`major.minor.patch.run_number`)
- Backend: `springBoot { buildInfo() }` generates `META-INF/build-info.properties` in the jar; version passed via `-Pversion` to Gradle in both Dockerfile and CI; exposed via `/actuator/info`
- Frontend: `__APP_VERSION__` defined in `vite.config.ts` from `npm_package_version`; `package.json` rewritten with `jq` before build in both Dockerfile and CI; `src/lib/version.ts` exports `appVersion` for use in the app

## Test plan

- [ ] Local backend: `./gradlew bootRun` → `curl localhost:8080/actuator/info` returns `{"build":{"version":"0.1.0-SNAPSHOT",...}}`
- [ ] Local frontend: `bun run dev` → `appVersion` resolves to `"0.0.1"`
- [ ] Simulated CI backend: `docker build --build-arg APP_VERSION=0.1.0.99 -t todo-backend backend/` → `curl /actuator/info` returns `{"build":{"version":"0.1.0.99",...}}`
- [ ] Simulated CI frontend: `docker build --build-arg APP_VERSION=0.0.1.99 -t todo-frontend frontend/` → `grep -r "0.0.1.99" build/` finds the version in the bundle
- [ ] After merge: inspect release run — `compute-version` outputs correct values, Docker builds receive them as build args

🤖 Generated with [Claude Code](https://claude.com/claude-code)