### PR TITLE
chore(deps): bump Kotlin from 2.2.21 to 2.3.20 in /backend

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -1,9 +1,9 @@
 plugins {
-	kotlin("jvm") version "2.2.21"
-	kotlin("plugin.spring") version "2.2.21"
+	kotlin("jvm") version "2.3.20"
+	kotlin("plugin.spring") version "2.3.20"
 	id("org.springframework.boot") version "4.0.5"
 	id("io.spring.dependency-management") version "1.1.7"
-	kotlin("plugin.jpa") version "2.2.21"
+	kotlin("plugin.jpa") version "2.3.20"
 }
 
 group = "com.github.matthiasbalke"


### PR DESCRIPTION
## Summary

Batches the three individual Dependabot PRs that each bump a single Kotlin plugin:

- #19 — `kotlin("plugin.jpa")` 2.2.21 → 2.3.20
- #20 — `kotlin("plugin.spring")` 2.2.21 → 2.3.20
- #22 — `kotlin("jvm")` 2.2.21 → 2.3.20

All three touch `backend/build.gradle.kts` and are part of the same Kotlin release, so they are applied together in one commit.

## Test plan
- [ ] `./gradlew build` passes with Kotlin 2.3.20
- [ ] CI passes (backend tests)

Closes #19, closes #20, closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)