### PR TITLE
feat: enrich notify-addon payload with Docker tags and ref name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,3 +112,30 @@ jobs:
         - registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+  notify-addon:
+    name: Notify addon-todo
+    needs: [build-all-in-one]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract tags from Docker metadata
+        id: meta
+        env:
+          META_JSON: ${{ needs.build-all-in-one.outputs.meta-json }}
+        run: |
+          TAGS=$(echo "$META_JSON" | jq -c '[.tags[] | split(":") | last]')
+          echo "tags=$TAGS" >> $GITHUB_OUTPUT
+      - name: Dispatch update to addon-todo
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
+        with:
+          token: ${{ secrets.DISPATCH_TOKEN }}
+          repository: matthiasbalke/addon-todo
+          event-type: update
+          client-payload: >
+            {
+              "app": "todo",
+              "name": "Todo",
+              "repository": "${{ github.repository }}",
+              "ref": "${{ github.ref_name }}",
+              "tags": ${{ steps.meta.outputs.tags }}
+            }


### PR DESCRIPTION
## Summary
- Replaces manual `sha-$(cut -c1-7)` computation with `jq` parsing of `needs.build-all-in-one.outputs.meta-json` to get ground-truth tags from Docker metadata
- Adds `ref` field (`github.ref_name` — `main` or `v1.x.y`) and `tags` JSON array to dispatch payload; removes redundant `version` field
- Removes `if: github.ref == 'refs/heads/main'` guard so `v*` tag pushes also trigger the notification

## Test plan
- [ ] Push to `main` → payload contains `"ref": "main"` and `"tags": ["main", "sha-XXXXXXX"]`
- [ ] Push a `v*` tag → payload contains `"ref": "v1.x.y"` and `"tags": ["1.x.y", "1.x", "sha-XXXXXXX"]`
- [ ] Check `matthiasbalke/addon-todo` Actions/dispatch events confirm event arrived

🤖 Generated with [Claude Code](https://claude.com/claude-code)