### PR TITLE
fix: keep SSE connections alive behind Cloudflare and Nginx

### DIFF
--- a/all-in-one/nginx.conf
+++ b/all-in-one/nginx.conf
@@ -6,6 +6,7 @@ http {
 
         location /api/ {
             proxy_pass http://localhost:8080;
+            proxy_buffering off;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/backend/src/main/kotlin/com/github/matthiasbalke/todo/TodoApplication.kt
+++ b/backend/src/main/kotlin/com/github/matthiasbalke/todo/TodoApplication.kt
@@ -3,9 +3,11 @@ package com.github.matthiasbalke.todo
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.runApplication
+import org.springframework.scheduling.annotation.EnableScheduling
 import com.github.matthiasbalke.todo.auth.JwtProperties
 
 @SpringBootApplication
+@EnableScheduling
 @EnableConfigurationProperties(JwtProperties::class)
 class TodoApplication
 

--- a/backend/src/main/kotlin/com/github/matthiasbalke/todo/sse/SseController.kt
+++ b/backend/src/main/kotlin/com/github/matthiasbalke/todo/sse/SseController.kt
@@ -1,6 +1,7 @@
 package com.github.matthiasbalke.todo.sse
 
 import com.github.matthiasbalke.todo.lists.ListAccessService
+import jakarta.servlet.http.HttpServletResponse
 import org.springframework.http.MediaType
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.GetMapping
@@ -23,7 +24,10 @@ class SseController(
         @AuthenticationPrincipal userId: UUID,
         @PathVariable listId: UUID,
         @RequestHeader(value = "Last-Event-ID", required = false) lastEventId: String?,
+        response: HttpServletResponse,
     ): SseEmitter {
+        response.setHeader("X-Accel-Buffering", "no")
+        response.setHeader("Cache-Control", "no-cache")
         listAccessService.requireMembership(listId, userId)
         return ssePublisher.subscribe(listId, lastEventId?.toLongOrNull())
     }

--- a/backend/src/main/kotlin/com/github/matthiasbalke/todo/sse/SsePublisher.kt
+++ b/backend/src/main/kotlin/com/github/matthiasbalke/todo/sse/SsePublisher.kt
@@ -1,6 +1,7 @@
 package com.github.matthiasbalke.todo.sse
 
 import org.springframework.http.MediaType
+import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
 import java.util.UUID
@@ -48,6 +49,16 @@ class SsePublisher {
         emitter.onError { cleanup.run() }
 
         return emitter
+    }
+
+    @Scheduled(fixedDelayString = "\${sse.heartbeat.interval-ms:25000}")
+    fun sendHeartbeats() {
+        emitters.values.forEach { list ->
+            list.forEach { emitter ->
+                try { emitter.send(SseEmitter.event().comment("ping")) }
+                catch (_: Exception) { /* stale emitters cleaned up by error handler */ }
+            }
+        }
     }
 
     fun publish(event: ListEvent) {

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -23,6 +23,10 @@ jwt:
   access-token-ttl: PT15M
   refresh-token-ttl: P30D
 
+sse:
+  heartbeat:
+    interval-ms: 25000
+
 app:
   cors:
     allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:5173}

--- a/backend/src/test/kotlin/com/github/matthiasbalke/todo/sse/SseIntegrationTest.kt
+++ b/backend/src/test/kotlin/com/github/matthiasbalke/todo/sse/SseIntegrationTest.kt
@@ -16,6 +16,7 @@ import java.net.URI
 import java.util.UUID
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @Import(TestcontainersConfiguration::class)
@@ -95,6 +96,67 @@ class SseIntegrationTest {
             .withFailMessage("item.created SSE event did not arrive within 1 second")
             .isTrue()
         assertThat(receivedEventType).isEqualTo("item.created")
+    }
+
+    @Test
+    fun `SSE response should include X-Accel-Buffering no header`() {
+        val user = userRepository.save(User(email = "sse-buf-${UUID.randomUUID()}@example.com", displayName = "SSE Buf Test"))
+        val token = jwtTokenService.generateAccessToken(user)
+        val listId = post("/api/lists", """{"name":"SSE Buf Test List"}""", token)
+            .let { mapper.readTree(it)["id"].asText() }
+
+        val conn = openConnection("/api/lists/$listId/events?token=$token")
+        conn.setRequestProperty("Accept", "text/event-stream")
+        conn.connectTimeout = 5_000
+        conn.readTimeout = 5_000
+        conn.connect()
+
+        assertThat(conn.getHeaderField("X-Accel-Buffering")).isEqualTo("no")
+        conn.disconnect()
+    }
+
+    @Test
+    fun `SSE should send periodic heartbeat comments after the initial connected comment`() {
+        val user = userRepository.save(User(email = "sse-hb-${UUID.randomUUID()}@example.com", displayName = "SSE HB Test"))
+        val token = jwtTokenService.generateAccessToken(user)
+        val listId = post("/api/lists", """{"name":"SSE HB Test List"}""", token)
+            .let { mapper.readTree(it)["id"].asText() }
+
+        val commentCount = AtomicInteger(0)
+        val secondComment = CountDownLatch(2)
+        var threadError: Throwable? = null
+
+        val thread = Thread {
+            try {
+                val conn = openConnection("/api/lists/$listId/events?token=$token")
+                conn.setRequestProperty("Accept", "text/event-stream")
+                conn.connectTimeout = 5_000
+                conn.readTimeout = 5_000
+                conn.connect()
+
+                conn.inputStream.bufferedReader().use { reader ->
+                    var line: String?
+                    while (reader.readLine().also { line = it } != null) {
+                        if (line!!.startsWith(":")) {
+                            val count = commentCount.incrementAndGet()
+                            secondComment.countDown()
+                            if (count >= 2) return@Thread
+                        }
+                    }
+                }
+            } catch (e: Throwable) {
+                threadError = e
+                repeat(2) { secondComment.countDown() }
+            }
+        }
+        thread.isDaemon = true
+        thread.start()
+
+        assertThat(secondComment.await(3, TimeUnit.SECONDS))
+            .withFailMessage("Did not receive 2 SSE comments within 3s. Thread error: $threadError")
+            .isTrue()
+        assertThat(threadError).isNull()
+        assertThat(commentCount.get()).isGreaterThanOrEqualTo(2)
     }
 
     private fun post(path: String, body: String, token: String): String {

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -11,6 +11,10 @@ webauthn:
     id: localhost
     name: Todo Test
 
+sse:
+  heartbeat:
+    interval-ms: 500
+
 app:
   cors:
     allowed-origins: http://localhost:5173


### PR DESCRIPTION
## Summary

- Set `X-Accel-Buffering: no` and `Cache-Control: no-cache` on SSE responses so Cloudflare and Nginx do not buffer the event stream
- Add a scheduled heartbeat (`: ping` every 25 s) to prevent Cloudflare's ~100 s idle-connection timeout from silently dropping SSE streams
- Add `proxy_buffering off` to `all-in-one/nginx.conf` `/api/` location block

## Test plan

- [ ] New integration test: `SSE response should include X-Accel-Buffering no header` — verifies the response header is set
- [ ] New integration test: `SSE should send periodic heartbeat comments after the initial connected comment` — verifies ≥2 SSE comments arrive within 3 s (test config uses 500 ms heartbeat interval)
- [ ] `./gradlew test` — all tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)