### PR TITLE
UI enhancements

### DIFF
--- a/docs/features/category-config-mobile.md
+++ b/docs/features/category-config-mobile.md
@@ -1,0 +1,33 @@
+# Category Config: Mobile Visibility & Color Picker Fix
+
+## Overview
+
+Two usability bugs in `CategoryConfigDialog.svelte` made the category configuration unusable on mobile. Edit and delete buttons were hidden behind a CSS hover state that touch devices cannot trigger. Separately, clicking a color swatch while editing a category closed edit mode before the color change was saved, because the input's `onblur` handler fired before the swatch's `onclick`.
+
+## Design Decisions
+
+### Mobile button visibility
+
+**Problem:** `opacity-0 group-hover:opacity-100` is invisible on touch devices because there is no hover state.
+
+**Fix:** Use `sm:opacity-0 sm:group-hover:opacity-100` instead of `opacity-0 group-hover:opacity-100`. This makes the buttons always visible on small screens (mobile) and hover-only on `sm` and above (≥640 px, typically desktop/tablet with mouse).
+
+**Alternative considered:** `@media (hover: none)` via a custom Tailwind variant. Rejected as more complex and less idiomatic — the screen-size breakpoint is a well-understood proxy for touch vs. pointer devices in this app.
+
+### Color picker blur conflict
+
+**Problem:** The edit name input uses `onblur={() => commitEdit(cat)}` to auto-save when focus leaves. When the user clicks a color swatch, the browser fires `blur` on the input before `click` on the swatch. `commitEdit` saves and sets `editingId = null`, ending edit mode. The `onclick` then fires, but `editingColor` is updated after the save has already been dispatched, so the color change is lost.
+
+**Fix:** Add `onmousedown={(e) => e.preventDefault()}` to the color swatch buttons in edit mode. `preventDefault` on `mousedown` stops the browser from moving focus away from the input, so `blur` is never triggered, and the `onclick` can update `editingColor` while edit mode remains open.
+
+This is the standard browser technique for toolbar buttons (like bold/italic in rich-text editors) that must not steal focus from the active input.
+
+## Security Considerations
+
+Pure frontend UI change. No new API calls, no data exposed beyond what the existing dialog already shows. No security impact.
+
+## Implementation Plan
+
+1. In `CategoryConfigDialog.svelte`, change edit/delete button classes from `opacity-0 group-hover:opacity-100` to `sm:opacity-0 sm:group-hover:opacity-100` so buttons are always visible on mobile.
+2. Add `onmousedown={(e) => e.preventDefault()}` to each color swatch button in the inline-edit row to prevent the name input from losing focus on click.
+3. Run `bun run check` and `bun run test --run` to verify no regressions.

--- a/docs/features/fixed-bottom-add-bar.md
+++ b/docs/features/fixed-bottom-add-bar.md
@@ -1,0 +1,22 @@
+# Fixed Bottom Add Bar
+
+## Overview
+
+The "+ New list" and "+ Add item" buttons are fixed to the bottom of the viewport so they are always visible without scrolling, regardless of how many items are on screen.
+
+## Affected Pages
+
+- `/lists` — "+ New list" button
+- `/lists/[id]` — "+ Add item" button
+
+## Design Decisions
+
+- **`fixed bottom-0 left-0 right-0 z-20`** — pins the bar to the viewport bottom; `z-20` is above the header (`z-10`) and dropdown menus (`z-20` + `z-10` backdrop), so the bar stays visible but dialogs (which use `fixed inset-0`) cover it naturally.
+- **`max-w-2xl mx-auto` on the inner container** — matches the app layout's content width constraint so the button aligns with the list/item content on wide screens.
+- **`pb-20` on the scrollable content** — prevents the last list card or item from being hidden behind the fixed bar.
+- **`max-h-[70vh] overflow-y-auto` on the form wrapper** — `ItemForm` has 6+ fields and can be tall on mobile; capping at 70 vh keeps it scrollable within the bar without covering the whole screen.
+- **No changes to `ListForm` or `ItemForm`** — only the containing pages changed; the form components are unaffected.
+
+## Security Notes
+
+No security-relevant changes. This is a pure layout/UX change with no new API calls, no new data handling, and no changes to auth or permission logic.

--- a/docs/left-overs.md
+++ b/docs/left-overs.md
@@ -15,11 +15,6 @@ Tasks are small and independently verifiable (automated or manual). See `docs/re
  * Way to delete all checked List Items from a list.
 
 
-## 1. List Categories
- * The buttons to edit and delete categories are not visible on mobile phones, as they are only shown on hovering over the entry.
- * While editing a Category, one cannot change the color by clicking on the color picker. 
- 
-
 ## 1. Production
  * how do we monitor exceptions and errors in backend and frontend?
  * how to monitor functional metrics like, #registered users, #lists, mean(items per list), max(items per list), min(items per list)

--- a/docs/left-overs.md
+++ b/docs/left-overs.md
@@ -7,20 +7,18 @@ Tasks are small and independently verifiable (automated or manual). See `docs/re
 
 ## 1. Misc
 
- * Add List should always be displayed fixed at the bottom.
- * Cursor-based pagination params (cursor, limit) are accepted but unused in the initial implementation — the response always returns all items in one page.
+  * Cursor-based pagination params (cursor, limit) are accepted but unused in the initial implementation — the response always returns all items in one page.
 
 
 ## 1. List Items
- * Add Item should always be displayed fixed at the bottom.
  * The ItemForm keeps a single-user dropdown (picks first assignment). Multiple assignments must be possible.
  * Stars are not vertically aligned
  * Way to delete all checked List Items from a list.
 
 
 ## 1. List Categories
-
- * Edit Category, cannot change color.
+ * The buttons to edit and delete categories are not visible on mobile phones, as they are only shown on hovering over the entry.
+ * While editing a Category, one cannot change the color by clicking on the color picker. 
  * Remember last uses category per list and select it as default for next item.
 
 

--- a/docs/left-overs.md
+++ b/docs/left-overs.md
@@ -11,8 +11,7 @@ Tasks are small and independently verifiable (automated or manual). See `docs/re
 
 ## 1. List Items
  * The ItemForm keeps a single-user dropdown (picks first assignment). Multiple assignments must be possible.
- * Stars are not vertically aligned
- * Way to delete all checked List Items from a list.
+  * Way to delete all checked List Items from a list.
 
 
 ## 1. Production

--- a/docs/left-overs.md
+++ b/docs/left-overs.md
@@ -6,7 +6,6 @@ Tasks are small and independently verifiable (automated or manual). See `docs/re
 ---
 
 ## 1. Misc
-
   * Cursor-based pagination params (cursor, limit) are accepted but unused in the initial implementation — the response always returns all items in one page.
 
 
@@ -19,8 +18,7 @@ Tasks are small and independently verifiable (automated or manual). See `docs/re
 ## 1. List Categories
  * The buttons to edit and delete categories are not visible on mobile phones, as they are only shown on hovering over the entry.
  * While editing a Category, one cannot change the color by clicking on the color picker. 
- * Remember last uses category per list and select it as default for next item.
-
+ 
 
 ## 1. Production
  * how do we monitor exceptions and errors in backend and frontend?

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -167,6 +167,8 @@ Checkbox-based task list for tracking implementation progress. Tasks are small a
 ### Frontend
 - [x] Implement category group component (`CategoryGroup.svelte`): collapsible, shows category color and name, contains item cards
 - [x] Implement "no category" group rendered alongside named categories
+- [x] Fix edit/delete buttons invisible on mobile (replace hover-only opacity with responsive `sm:` prefix so buttons are always visible on small screens)
+- [x] Fix color picker in edit mode: clicking a swatch closed edit mode due to input blur firing before onclick — fixed with `onmousedown` preventDefault on swatches
 - [ ] Write Vitest component test: items are grouped correctly by category from mock data
 
 ---

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -337,6 +337,19 @@ Checkbox-based task list for tracking implementation progress. Tasks are small a
 
 ---
 
+## 16. Fixed Bottom Add Bar
+
+### Frontend
+- [x] Fix "+ New list" button to viewport bottom on `/lists` page
+- [x] Fix "+ Add item" button to viewport bottom on `/lists/[id]` page
+- [x] Add `pb-20` padding to scrollable content so last items are not hidden behind fixed bar
+- [x] Cap inline form height at `70vh` with internal scroll for tall forms (ItemForm)
+
+### Notes
+- See `docs/features/fixed-bottom-add-bar.md` for design decisions
+
+---
+
 ## 15. PWA & Offline
 
 ### Frontend

--- a/frontend/src/lib/components/CategoryConfigDialog.svelte
+++ b/frontend/src/lib/components/CategoryConfigDialog.svelte
@@ -165,6 +165,7 @@
                   {#each COLOR_SWATCHES as swatch}
                     <button
                       type="button"
+                      onmousedown={(e) => e.preventDefault()}
                       onclick={() => { editingColor = editingColor === swatch ? null : swatch; }}
                       class="w-4 h-4 rounded-full border-2 transition-all {editingColor === swatch ? 'border-gray-700 scale-110' : 'border-transparent'}"
                       style="background-color: {swatch}"
@@ -191,8 +192,8 @@
                   onkeydown={(e) => { if (e.key === 'Enter') startEdit(cat); }}
                 >{cat.name}</span>
               </div>
-              <button onclick={() => startEdit(cat)} class="p-0.5 text-gray-300 hover:text-gray-600 opacity-0 group-hover:opacity-100 transition-all" aria-label="Rename">✏️</button>
-              <button onclick={() => removeCat(cat)} class="p-0.5 text-gray-300 hover:text-red-500 opacity-0 group-hover:opacity-100 transition-all" aria-label="Delete">🗑</button>
+              <button onclick={() => startEdit(cat)} class="p-0.5 text-gray-300 hover:text-gray-600 sm:opacity-0 sm:group-hover:opacity-100 transition-all" aria-label="Rename">✏️</button>
+              <button onclick={() => removeCat(cat)} class="p-0.5 text-gray-300 hover:text-red-500 sm:opacity-0 sm:group-hover:opacity-100 transition-all" aria-label="Delete">🗑</button>
             {/if}
           </div>
         {/each}

--- a/frontend/src/lib/components/ItemCard.svelte
+++ b/frontend/src/lib/components/ItemCard.svelte
@@ -167,7 +167,7 @@
 
     <button
       onclick={handleStar}
-      class="flex-shrink-0 text-lg leading-none {item.starred ? 'text-yellow-400' : 'text-gray-200 hover:text-yellow-300'} transition-colors"
+      class="flex-shrink-0 self-center text-lg leading-none {item.starred ? 'text-yellow-400' : 'text-gray-200 hover:text-yellow-300'} transition-colors"
       aria-label={item.starred ? 'Unstar' : 'Star'}
     >★</button>
   </div>

--- a/frontend/src/lib/components/ItemCard.test.ts
+++ b/frontend/src/lib/components/ItemCard.test.ts
@@ -1,0 +1,34 @@
+import { render } from '@testing-library/svelte';
+import { describe, it, expect } from 'vitest';
+import ItemCard from './ItemCard.svelte';
+import type { TodoItem } from '$lib/mock-data';
+
+const baseItem: TodoItem = {
+  id: 'item-1',
+  listId: 'list-1',
+  title: 'Test item',
+  notes: null,
+  done: false,
+  starred: false,
+  dueDate: null,
+  categoryId: null,
+  assignedUserIds: [],
+  recurrenceRule: null,
+  parentItemId: null,
+  createdByUserId: null,
+  sortOrder: 1,
+  createdAt: '2024-01-01',
+};
+
+describe('ItemCard star button alignment', () => {
+  it('star button should have self-center class for vertical centering in flex-start container', () => {
+    const { container } = render(ItemCard, {
+      props: { item: baseItem, categories: [], users: [] },
+    });
+
+    const starButton = container.querySelector('button[aria-label="Star"]') ??
+                       container.querySelector('button[aria-label="Unstar"]');
+    expect(starButton).not.toBeNull();
+    expect(starButton!.className).toContain('self-center');
+  });
+});

--- a/frontend/src/lib/components/ItemForm.svelte
+++ b/frontend/src/lib/components/ItemForm.svelte
@@ -8,7 +8,8 @@
     categories,
     users,
     onsubmit,
-    oncancel
+    oncancel,
+    defaultCategoryId = ''
   }: {
     item?: TodoItem | null;
     listId: string;
@@ -16,6 +17,7 @@
     users: User[];
     onsubmit: (item: TodoItem) => Promise<void> | void;
     oncancel: () => void;
+    defaultCategoryId?: string;
   } = $props();
 
   const isNew = $derived(!item);
@@ -23,7 +25,7 @@
   let title = $state(untrack(() => item?.title ?? ''));
   let notes = $state(untrack(() => item?.notes ?? ''));
   let dueDate = $state(untrack(() => item?.dueDate ?? ''));
-  let categoryId = $state<string>(untrack(() => item?.categoryId ?? ''));
+  let categoryId = $state<string>(untrack(() => item?.categoryId ?? defaultCategoryId ?? ''));
   let assignedUserId = $state<string>(untrack(() => item?.assignedUserIds[0] ?? ''));
   let recurrencePreset = $state<string>(untrack(() => getInitialRecurrencePreset(item?.recurrenceRule ?? null)));
   let titleInput = $state<HTMLInputElement | null>(null);
@@ -72,7 +74,7 @@
         title = '';
         notes = '';
         dueDate = '';
-        categoryId = '';
+        categoryId = defaultCategoryId ?? '';
         assignedUserId = '';
         recurrencePreset = '';
         titleInput?.focus();

--- a/frontend/src/lib/listItemDefaults.ts
+++ b/frontend/src/lib/listItemDefaults.ts
@@ -1,0 +1,31 @@
+export type ListItemDefaults = {
+  lastCategoryId: string | null;
+};
+
+const key = (listId: string) => `todo_list_item_defaults_${listId}`;
+
+export function loadListItemDefaults(listId: string): ListItemDefaults | null {
+  try {
+    const raw = localStorage.getItem(key(listId));
+    if (!raw) return null;
+    return JSON.parse(raw) as ListItemDefaults;
+  } catch {
+    return null;
+  }
+}
+
+export function saveListItemDefaults(listId: string, d: ListItemDefaults): void {
+  try {
+    localStorage.setItem(key(listId), JSON.stringify(d));
+  } catch {
+    // ignore (e.g. private browsing quota exceeded)
+  }
+}
+
+export function deleteListItemDefaults(listId: string): void {
+  try {
+    localStorage.removeItem(key(listId));
+  } catch {
+    // ignore
+  }
+}

--- a/frontend/src/routes/(app)/lists/+page.svelte
+++ b/frontend/src/routes/(app)/lists/+page.svelte
@@ -25,7 +25,7 @@
   }
 </script>
 
-<div>
+<div class="pb-20">
   {#if isLoading()}
     <div class="space-y-3">
       {#each [1, 2, 3] as _}
@@ -47,13 +47,13 @@
         </a>
       {/each}
     </div>
+  {/if}
+</div>
 
-    {#if error}
-      <p class="mt-3 text-sm text-red-600">{error}</p>
-    {/if}
-
+<div class="fixed bottom-0 left-0 right-0 z-20 bg-white border-t border-gray-100 shadow-lg">
+  <div class="max-w-2xl mx-auto px-4 py-3">
     {#if showAddForm}
-      <div class="mt-4">
+      <div class="max-h-[70vh] overflow-y-auto">
         <ListForm
           onsubmit={handleSave}
           oncancel={() => { showAddForm = false; error = null; }}
@@ -63,10 +63,13 @@
       <button
         onclick={() => { showAddForm = true; }}
         disabled={saving}
-        class="mt-4 w-full py-3 border-2 border-dashed border-gray-200 rounded-xl text-sm text-gray-400 hover:border-gray-300 hover:text-gray-500 transition-colors disabled:opacity-50"
+        class="w-full py-3 border-2 border-dashed border-gray-200 rounded-xl text-sm text-gray-400 hover:border-gray-300 hover:text-gray-500 transition-colors disabled:opacity-50"
       >
         + New list
       </button>
     {/if}
-  {/if}
+    {#if error}
+      <p class="mt-2 text-sm text-red-600">{error}</p>
+    {/if}
+  </div>
 </div>

--- a/frontend/src/routes/(app)/lists/[id]/+page.svelte
+++ b/frontend/src/routes/(app)/lists/[id]/+page.svelte
@@ -9,6 +9,7 @@
   import type { SortField, SortDirection, TodoItem } from '$lib/mock-data';
   import { loadListPrefs, saveListPrefs, deleteListPrefs } from '$lib/listPrefs';
   import { loadListCategoryState, saveListCategoryState, deleteListCategoryState } from '$lib/listCategoryState';
+  import { loadListItemDefaults, saveListItemDefaults } from '$lib/listItemDefaults';
   import CategoryGroup from '$lib/components/CategoryGroup.svelte';
   import ItemForm from '$lib/components/ItemForm.svelte';
   import CategoryConfigDialog from '$lib/components/CategoryConfigDialog.svelte';
@@ -33,6 +34,8 @@
   const _savedPrefs = untrack(() => loadListPrefs(data.id));
   untrack(() => setHideDone(data.id, _savedPrefs?.hideDone ?? false));
   const _savedCategoryState = untrack(() => loadListCategoryState(data.id));
+  const _savedItemDefaults = untrack(() => loadListItemDefaults(data.id));
+  let lastCategoryId = $state<string | null>(_savedItemDefaults?.lastCategoryId ?? null);
   let collapsedMap = $state<Record<string, boolean>>(_savedCategoryState?.collapsed ?? {});
   let doneCollapsedMap = $state<Record<string, boolean>>(_savedCategoryState?.doneCollapsed ?? {});
   let filters = $state<Filters>({
@@ -111,6 +114,8 @@
   const grouped = $derived(groupByCategory(sorted, categories));
 
   async function handleAddItem(item: TodoItem) {
+    lastCategoryId = item.categoryId ?? null;
+    saveListItemDefaults(data.id, { lastCategoryId });
     try {
       await createItem(data.id, {
         title: item.title,
@@ -354,6 +359,7 @@
           users={data.users}
           onsubmit={handleAddItem}
           oncancel={() => { showAddForm = false; }}
+          defaultCategoryId={lastCategoryId ?? undefined}
         />
       </div>
     {:else}

--- a/frontend/src/routes/(app)/lists/[id]/+page.svelte
+++ b/frontend/src/routes/(app)/lists/[id]/+page.svelte
@@ -158,7 +158,7 @@
 {#if !list}
   <div class="text-center py-12 text-gray-400">List not found.</div>
 {:else}
-<div>
+<div class="pb-20">
   <div class="flex items-center gap-3 mb-4">
     <a href="/lists" class="text-gray-400 hover:text-gray-600">←</a>
     {#if editingTitle}
@@ -335,25 +335,6 @@
     {/each}
   </div>
 
-  {#if showAddForm}
-    <div class="mt-4">
-      <ItemForm
-        listId={data.id}
-        {categories}
-        users={data.users}
-        onsubmit={handleAddItem}
-        oncancel={() => { showAddForm = false; }}
-      />
-    </div>
-  {:else}
-    <button
-      onclick={() => { showAddForm = true; }}
-      class="mt-4 w-full py-3 border-2 border-dashed border-gray-200 rounded-xl text-sm text-gray-400 hover:border-gray-300 hover:text-gray-500 transition-colors"
-    >
-      + Add item
-    </button>
-  {/if}
-
   {#if showCategoryDialog}
     <CategoryConfigDialog {categories} listId={data.id} onclose={() => { showCategoryDialog = false; }} />
   {/if}
@@ -361,5 +342,28 @@
   {#if showMembersDialog}
     <MembersDialog listId={data.id} onclose={() => { showMembersDialog = false; }} />
   {/if}
+</div>
+
+<div class="fixed bottom-0 left-0 right-0 z-20 bg-white border-t border-gray-100 shadow-lg">
+  <div class="max-w-2xl mx-auto px-4 py-3">
+    {#if showAddForm}
+      <div class="max-h-[70vh] overflow-y-auto">
+        <ItemForm
+          listId={data.id}
+          {categories}
+          users={data.users}
+          onsubmit={handleAddItem}
+          oncancel={() => { showAddForm = false; }}
+        />
+      </div>
+    {:else}
+      <button
+        onclick={() => { showAddForm = true; }}
+        class="w-full py-3 border-2 border-dashed border-gray-200 rounded-xl text-sm text-gray-400 hover:border-gray-300 hover:text-gray-500 transition-colors"
+      >
+        + Add item
+      </button>
+    {/if}
+  </div>
 </div>
 {/if}


### PR DESCRIPTION
## Summary

- Edit and delete buttons in the category dialog were invisible on mobile because `opacity-0 group-hover:opacity-100` requires a hover state that touch devices don't have. Changed to `sm:opacity-0 sm:group-hover:opacity-100` so the buttons are always visible on small screens and hover-only on desktop (≥640 px).
- Color swatches in inline-edit mode couldn't be clicked because the name input's `onblur → commitEdit` handler fired before the swatch's `onclick`, closing edit mode before the color change was applied. Added `onmousedown={(e) => e.preventDefault()}` to the swatches to keep focus on the input.

## Test plan

- [ ] Open the category dialog on a mobile device or DevTools mobile emulation — verify edit (✏️) and delete (🗑) buttons are visible without tapping
- [ ] While editing a category name, click a color swatch — verify edit mode stays open and the selected color is highlighted
- [ ] Submit the edit — verify the new color is saved
- [ ] On desktop, verify edit/delete buttons still appear only on hover (not always visible)
- [ ] `bun run check` → 0 errors
- [ ] `bun run test --run` → all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)