### PR TITLE
feat: list groups with drag-and-drop reorder and assignment

### DIFF
--- a/backend/src/main/kotlin/com/github/matthiasbalke/todo/lists/List.kt
+++ b/backend/src/main/kotlin/com/github/matthiasbalke/todo/lists/List.kt
@@ -30,4 +30,10 @@ class List(
 
     @Column(name = "created_at", nullable = false, updatable = false)
     val createdAt: Instant = Instant.now(),
+
+    @Column(name = "group_id")
+    var groupId: UUID? = null,
+
+    @Column(name = "sort_order_in_group", nullable = false)
+    var sortOrderInGroup: Int = 0,
 )

--- a/backend/src/main/kotlin/com/github/matthiasbalke/todo/lists/ListController.kt
+++ b/backend/src/main/kotlin/com/github/matthiasbalke/todo/lists/ListController.kt
@@ -5,6 +5,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
@@ -19,6 +20,7 @@ import java.util.UUID
 @RequestMapping("/api/lists")
 class ListController(
     private val listService: ListService,
+    private val listGroupService: ListGroupService,
     private val userRepository: UserRepository,
 ) {
 
@@ -39,7 +41,13 @@ class ListController(
         val name: String,
         val emoji: String?,
         val createdAt: Instant,
+        val groupId: UUID?,
+        val sortOrderInGroup: Int,
     )
+
+    data class AssignGroupRequest(val groupId: UUID?)
+
+    data class ReorderInGroupRequest(val sortOrder: Int)
 
     data class CreateListRequest(
         val name: String,
@@ -124,6 +132,20 @@ class ListController(
         @PathVariable id: UUID,
     ) = listService.deleteList(id, userId)
 
+    @PatchMapping("/{id}/group")
+    fun assignGroup(
+        @AuthenticationPrincipal userId: UUID,
+        @PathVariable id: UUID,
+        @RequestBody body: AssignGroupRequest,
+    ): ListSummaryDto = listGroupService.assignListToGroup(id, userId, body.groupId).toSummaryDto()
+
+    @PatchMapping("/{id}/group-order")
+    fun reorderInGroup(
+        @AuthenticationPrincipal userId: UUID,
+        @PathVariable id: UUID,
+        @RequestBody body: ReorderInGroupRequest,
+    ): ListSummaryDto = listGroupService.reorderListInGroup(id, userId, body.sortOrder).toSummaryDto()
+
     // ─── Member management ───────────────────────────────────────────────────
 
     @GetMapping("/{id}/members")
@@ -174,6 +196,8 @@ class ListController(
         name = name,
         emoji = emoji,
         createdAt = createdAt,
+        groupId = groupId,
+        sortOrderInGroup = sortOrderInGroup,
     )
 
     private fun ListMembership.toMemberDto(): MemberDto {

--- a/backend/src/main/kotlin/com/github/matthiasbalke/todo/lists/ListGroup.kt
+++ b/backend/src/main/kotlin/com/github/matthiasbalke/todo/lists/ListGroup.kt
@@ -1,0 +1,27 @@
+package com.github.matthiasbalke.todo.lists
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.Instant
+import java.util.UUID
+
+@Entity
+@Table(name = "list_groups")
+class ListGroup(
+    @Id
+    val id: UUID = UUID.randomUUID(),
+
+    @Column(name = "user_id", nullable = false)
+    val userId: UUID,
+
+    @Column(nullable = false)
+    var name: String,
+
+    @Column(name = "sort_order", nullable = false)
+    var sortOrder: Int = 0,
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    val createdAt: Instant = Instant.now(),
+)

--- a/backend/src/main/kotlin/com/github/matthiasbalke/todo/lists/ListGroupController.kt
+++ b/backend/src/main/kotlin/com/github/matthiasbalke/todo/lists/ListGroupController.kt
@@ -1,0 +1,83 @@
+package com.github.matthiasbalke.todo.lists
+
+import org.springframework.http.HttpStatus
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+import java.time.Instant
+import java.util.UUID
+
+@RestController
+@RequestMapping("/api/list-groups")
+class ListGroupController(
+    private val listGroupService: ListGroupService,
+) {
+
+    // ─── DTOs ────────────────────────────────────────────────────────────────
+
+    data class ListGroupDto(
+        val id: UUID,
+        val userId: UUID,
+        val name: String,
+        val sortOrder: Int,
+        val createdAt: Instant,
+    )
+
+    data class CreateGroupRequest(val name: String)
+
+    data class RenameGroupRequest(val name: String)
+
+    data class ReorderGroupRequest(val sortOrder: Int)
+
+    // ─── Endpoints ───────────────────────────────────────────────────────────
+
+    @GetMapping
+    fun getGroups(@AuthenticationPrincipal userId: UUID): kotlin.collections.List<ListGroupDto> =
+        listGroupService.getGroupsForUser(userId).map { it.toDto() }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    fun createGroup(
+        @AuthenticationPrincipal userId: UUID,
+        @RequestBody body: CreateGroupRequest,
+    ): ListGroupDto = listGroupService.createGroup(userId, body.name).toDto()
+
+    @PutMapping("/{gid}")
+    fun renameGroup(
+        @AuthenticationPrincipal userId: UUID,
+        @PathVariable gid: UUID,
+        @RequestBody body: RenameGroupRequest,
+    ): ListGroupDto = listGroupService.renameGroup(gid, userId, body.name).toDto()
+
+    @DeleteMapping("/{gid}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun deleteGroup(
+        @AuthenticationPrincipal userId: UUID,
+        @PathVariable gid: UUID,
+    ) = listGroupService.deleteGroup(gid, userId)
+
+    @PatchMapping("/{gid}/order")
+    fun reorderGroup(
+        @AuthenticationPrincipal userId: UUID,
+        @PathVariable gid: UUID,
+        @RequestBody body: ReorderGroupRequest,
+    ): ListGroupDto = listGroupService.reorderGroup(gid, userId, body.sortOrder).toDto()
+
+    // ─── Mapping helpers ─────────────────────────────────────────────────────
+
+    private fun ListGroup.toDto() = ListGroupDto(
+        id = id,
+        userId = userId,
+        name = name,
+        sortOrder = sortOrder,
+        createdAt = createdAt,
+    )
+}

--- a/backend/src/main/kotlin/com/github/matthiasbalke/todo/lists/ListGroupRepository.kt
+++ b/backend/src/main/kotlin/com/github/matthiasbalke/todo/lists/ListGroupRepository.kt
@@ -1,0 +1,13 @@
+package com.github.matthiasbalke.todo.lists
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import java.util.UUID
+
+interface ListGroupRepository : JpaRepository<ListGroup, UUID> {
+    fun findAllByUserIdOrderBySortOrder(userId: UUID): kotlin.collections.List<ListGroup>
+
+    @Query("SELECT COALESCE(MAX(g.sortOrder), -1) FROM ListGroup g WHERE g.userId = :userId")
+    fun maxSortOrderByUserId(@Param("userId") userId: UUID): Int
+}

--- a/backend/src/main/kotlin/com/github/matthiasbalke/todo/lists/ListGroupService.kt
+++ b/backend/src/main/kotlin/com/github/matthiasbalke/todo/lists/ListGroupService.kt
@@ -1,0 +1,86 @@
+package com.github.matthiasbalke.todo.lists
+
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.web.server.ResponseStatusException
+import java.util.UUID
+
+@Service
+class ListGroupService(
+    private val listGroupRepository: ListGroupRepository,
+    private val listRepository: ListRepository,
+    private val listAccessService: ListAccessService,
+) {
+
+    fun getGroupsForUser(userId: UUID): kotlin.collections.List<ListGroup> =
+        listGroupRepository.findAllByUserIdOrderBySortOrder(userId)
+
+    @Transactional
+    fun createGroup(userId: UUID, name: String): ListGroup {
+        val maxOrder = listGroupRepository.maxSortOrderByUserId(userId)
+        return listGroupRepository.save(
+            ListGroup(userId = userId, name = name, sortOrder = maxOrder + 1)
+        )
+    }
+
+    @Transactional
+    fun renameGroup(groupId: UUID, userId: UUID, name: String): ListGroup {
+        val group = requireOwnership(groupId, userId)
+        group.name = name
+        return listGroupRepository.save(group)
+    }
+
+    @Transactional
+    fun deleteGroup(groupId: UUID, userId: UUID) {
+        requireOwnership(groupId, userId)
+        // Set groupId to null on all lists in this group (DB ON DELETE SET NULL handles it,
+        // but we clear in-memory state by deleting directly)
+        listGroupRepository.deleteById(groupId)
+    }
+
+    @Transactional
+    fun reorderGroup(groupId: UUID, userId: UUID, newSortOrder: Int): ListGroup {
+        val group = requireOwnership(groupId, userId)
+        group.sortOrder = newSortOrder
+        return listGroupRepository.save(group)
+    }
+
+    @Transactional
+    fun assignListToGroup(listId: UUID, userId: UUID, groupId: UUID?): com.github.matthiasbalke.todo.lists.List {
+        listAccessService.requireMembership(listId, userId)
+        if (groupId != null) {
+            val group = listGroupRepository.findById(groupId).orElseThrow {
+                ResponseStatusException(HttpStatus.NOT_FOUND, "Group not found")
+            }
+            if (group.userId != userId) {
+                throw ResponseStatusException(HttpStatus.FORBIDDEN, "You do not own this group")
+            }
+        }
+        val list = listRepository.findById(listId).orElseThrow {
+            ResponseStatusException(HttpStatus.NOT_FOUND, "List not found")
+        }
+        list.groupId = groupId
+        return listRepository.save(list)
+    }
+
+    @Transactional
+    fun reorderListInGroup(listId: UUID, userId: UUID, newSortOrder: Int): com.github.matthiasbalke.todo.lists.List {
+        listAccessService.requireMembership(listId, userId)
+        val list = listRepository.findById(listId).orElseThrow {
+            ResponseStatusException(HttpStatus.NOT_FOUND, "List not found")
+        }
+        list.sortOrderInGroup = newSortOrder
+        return listRepository.save(list)
+    }
+
+    private fun requireOwnership(groupId: UUID, userId: UUID): ListGroup {
+        val group = listGroupRepository.findById(groupId).orElseThrow {
+            ResponseStatusException(HttpStatus.NOT_FOUND, "Group not found")
+        }
+        if (group.userId != userId) {
+            throw ResponseStatusException(HttpStatus.FORBIDDEN, "You do not own this group")
+        }
+        return group
+    }
+}

--- a/backend/src/main/resources/db/migration/V6__create_list_groups.sql
+++ b/backend/src/main/resources/db/migration/V6__create_list_groups.sql
@@ -1,0 +1,13 @@
+CREATE TABLE list_groups (
+    id         UUID         PRIMARY KEY,
+    user_id    UUID         NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    name       VARCHAR(255) NOT NULL,
+    sort_order INT          NOT NULL DEFAULT 0,
+    created_at TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_list_groups_user_id ON list_groups(user_id);
+
+ALTER TABLE lists
+    ADD COLUMN group_id            UUID REFERENCES list_groups(id) ON DELETE SET NULL,
+    ADD COLUMN sort_order_in_group INT  NOT NULL DEFAULT 0;

--- a/backend/src/test/kotlin/com/github/matthiasbalke/todo/lists/ListGroupIntegrationTest.kt
+++ b/backend/src/test/kotlin/com/github/matthiasbalke/todo/lists/ListGroupIntegrationTest.kt
@@ -1,0 +1,295 @@
+package com.github.matthiasbalke.todo.lists
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.github.matthiasbalke.todo.AbstractIntegrationTest
+import com.github.matthiasbalke.todo.auth.JwtTokenService
+import com.github.matthiasbalke.todo.auth.User
+import com.github.matthiasbalke.todo.auth.UserRepository
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.delete
+import org.springframework.test.web.servlet.get
+import org.springframework.test.web.servlet.patch
+import org.springframework.test.web.servlet.post
+import org.springframework.test.web.servlet.put
+import java.util.UUID
+
+@AutoConfigureMockMvc
+class ListGroupIntegrationTest : AbstractIntegrationTest() {
+
+    @Autowired private lateinit var mockMvc: MockMvc
+    @Autowired private lateinit var userRepository: UserRepository
+    @Autowired private lateinit var jwtTokenService: JwtTokenService
+
+    private fun createUser(email: String = "user-${UUID.randomUUID()}@example.com"): User =
+        userRepository.save(User(email = email, displayName = "Test User"))
+
+    private fun bearerHeader(user: User) = "Bearer ${jwtTokenService.generateAccessToken(user)}"
+
+    private val mapper = ObjectMapper()
+
+    // ─── Helpers ──────────────────────────────────────────────────────────────
+
+    private fun createGroupAsUser(user: User, name: String): UUID {
+        val result = mockMvc.post("/api/list-groups") {
+            header("Authorization", bearerHeader(user))
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"name":"$name"}"""
+        }.andExpect { status { isCreated() } }.andReturn()
+        return UUID.fromString(mapper.readTree(result.response.contentAsString)["id"].asText())
+    }
+
+    private fun createListAsUser(user: User, name: String): UUID {
+        val result = mockMvc.post("/api/lists") {
+            header("Authorization", bearerHeader(user))
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"name":"$name"}"""
+        }.andExpect { status { isCreated() } }.andReturn()
+        return UUID.fromString(mapper.readTree(result.response.contentAsString)["id"].asText())
+    }
+
+    // ─── POST /api/list-groups ────────────────────────────────────────────────
+
+    @Test
+    fun `POST list-groups - creates group and appears in GET`() {
+        val user = createUser()
+
+        mockMvc.post("/api/list-groups") {
+            header("Authorization", bearerHeader(user))
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"name":"Home"}"""
+        }.andExpect {
+            status { isCreated() }
+            jsonPath("$.id") { exists() }
+            jsonPath("$.name") { value("Home") }
+            jsonPath("$.sortOrder") { exists() }
+        }
+
+        mockMvc.get("/api/list-groups") {
+            header("Authorization", bearerHeader(user))
+        }.andExpect {
+            status { isOk() }
+            jsonPath("$[?(@.name == 'Home')]") { exists() }
+        }
+    }
+
+    @Test
+    fun `POST list-groups - creating a second group succeeds and gets incremented sortOrder`() {
+        val user = createUser()
+        createGroupAsUser(user, "Group A")   // sortOrder 0
+        mockMvc.post("/api/list-groups") {
+            header("Authorization", bearerHeader(user))
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"name":"Group B"}"""
+        }.andExpect {
+            status { isCreated() }
+            jsonPath("$.sortOrder") { value(1) }
+        }
+    }
+
+    // ─── PUT /api/list-groups/{gid} ───────────────────────────────────────────
+
+    @Test
+    fun `PUT list-groups - gid - renames group`() {
+        val user = createUser()
+        val gid = createGroupAsUser(user, "Old Name")
+
+        mockMvc.put("/api/list-groups/$gid") {
+            header("Authorization", bearerHeader(user))
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"name":"New Name"}"""
+        }.andExpect {
+            status { isOk() }
+            jsonPath("$.name") { value("New Name") }
+        }
+    }
+
+    @Test
+    fun `PUT list-groups - gid - non-owner gets 403`() {
+        val owner = createUser()
+        val other = createUser()
+        val gid = createGroupAsUser(owner, "Private Group")
+
+        mockMvc.put("/api/list-groups/$gid") {
+            header("Authorization", bearerHeader(other))
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"name":"Hijacked"}"""
+        }.andExpect {
+            status { isForbidden() }
+        }
+    }
+
+    // ─── DELETE /api/list-groups/{gid} ────────────────────────────────────────
+
+    @Test
+    fun `DELETE list-groups - gid - deletes group and lists become ungrouped`() {
+        val user = createUser()
+        val gid = createGroupAsUser(user, "To Delete")
+        val listId = createListAsUser(user, "My List")
+
+        // Assign list to group
+        mockMvc.patch("/api/lists/$listId/group") {
+            header("Authorization", bearerHeader(user))
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"groupId":"$gid"}"""
+        }.andExpect { status { isOk() } }
+
+        // Delete group
+        mockMvc.delete("/api/list-groups/$gid") {
+            header("Authorization", bearerHeader(user))
+        }.andExpect {
+            status { isNoContent() }
+        }
+
+        // List should now be ungrouped
+        mockMvc.get("/api/lists") {
+            header("Authorization", bearerHeader(user))
+        }.andExpect {
+            status { isOk() }
+            jsonPath("$[?(@.id == '$listId')].groupId") { value(null) }
+        }
+    }
+
+    @Test
+    fun `DELETE list-groups - gid - non-owner gets 403`() {
+        val owner = createUser()
+        val other = createUser()
+        val gid = createGroupAsUser(owner, "Private Group")
+
+        mockMvc.delete("/api/list-groups/$gid") {
+            header("Authorization", bearerHeader(other))
+        }.andExpect {
+            status { isForbidden() }
+        }
+    }
+
+    // ─── PATCH /api/list-groups/{gid}/order ───────────────────────────────────
+
+    @Test
+    fun `PATCH list-groups - gid - order - updates sortOrder`() {
+        val user = createUser()
+        val gid = createGroupAsUser(user, "Reorder Me")
+
+        mockMvc.patch("/api/list-groups/$gid/order") {
+            header("Authorization", bearerHeader(user))
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"sortOrder":42}"""
+        }.andExpect {
+            status { isOk() }
+            jsonPath("$.sortOrder") { value(42) }
+        }
+    }
+
+    @Test
+    fun `PATCH list-groups - gid - order - non-owner gets 403`() {
+        val owner = createUser()
+        val other = createUser()
+        val gid = createGroupAsUser(owner, "Private Group")
+
+        mockMvc.patch("/api/list-groups/$gid/order") {
+            header("Authorization", bearerHeader(other))
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"sortOrder":0}"""
+        }.andExpect {
+            status { isForbidden() }
+        }
+    }
+
+    // ─── PATCH /api/lists/{id}/group ──────────────────────────────────────────
+
+    @Test
+    fun `PATCH lists - id - group - assigns list to group and visible in GET lists`() {
+        val user = createUser()
+        val gid = createGroupAsUser(user, "Home")
+        val listId = createListAsUser(user, "Groceries")
+
+        mockMvc.patch("/api/lists/$listId/group") {
+            header("Authorization", bearerHeader(user))
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"groupId":"$gid"}"""
+        }.andExpect {
+            status { isOk() }
+            jsonPath("$.groupId") { value(gid.toString()) }
+        }
+
+        mockMvc.get("/api/lists") {
+            header("Authorization", bearerHeader(user))
+        }.andExpect {
+            status { isOk() }
+            jsonPath("$[?(@.id == '$listId')].groupId") { value(gid.toString()) }
+        }
+    }
+
+    @Test
+    fun `PATCH lists - id - group - unassigns list when groupId is null`() {
+        val user = createUser()
+        val gid = createGroupAsUser(user, "Home")
+        val listId = createListAsUser(user, "Groceries")
+
+        mockMvc.patch("/api/lists/$listId/group") {
+            header("Authorization", bearerHeader(user))
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"groupId":"$gid"}"""
+        }.andExpect { status { isOk() } }
+
+        mockMvc.patch("/api/lists/$listId/group") {
+            header("Authorization", bearerHeader(user))
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"groupId":null}"""
+        }.andExpect {
+            status { isOk() }
+            jsonPath("$.groupId") { value(null) }
+        }
+    }
+
+    @Test
+    fun `PATCH lists - id - group - non-member gets 403`() {
+        val owner = createUser()
+        val stranger = createUser()
+        val gid = createGroupAsUser(stranger, "Stranger Group")
+        val listId = createListAsUser(owner, "Owner List")
+
+        mockMvc.patch("/api/lists/$listId/group") {
+            header("Authorization", bearerHeader(stranger))
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"groupId":"$gid"}"""
+        }.andExpect {
+            status { isForbidden() }
+        }
+    }
+
+    // ─── PATCH /api/lists/{id}/group-order ────────────────────────────────────
+
+    @Test
+    fun `PATCH lists - id - group-order - updates sortOrderInGroup`() {
+        val user = createUser()
+        val listId = createListAsUser(user, "My List")
+
+        mockMvc.patch("/api/lists/$listId/group-order") {
+            header("Authorization", bearerHeader(user))
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"sortOrder":5}"""
+        }.andExpect {
+            status { isOk() }
+            jsonPath("$.sortOrderInGroup") { value(5) }
+        }
+    }
+
+    @Test
+    fun `PATCH lists - id - group-order - non-member gets 403`() {
+        val owner = createUser()
+        val stranger = createUser()
+        val listId = createListAsUser(owner, "Owner List")
+
+        mockMvc.patch("/api/lists/$listId/group-order") {
+            header("Authorization", bearerHeader(stranger))
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"sortOrder":0}"""
+        }.andExpect {
+            status { isForbidden() }
+        }
+    }
+}

--- a/docs/features/list-dnd-and-ux.md
+++ b/docs/features/list-dnd-and-ux.md
@@ -1,0 +1,32 @@
+# List Drag-and-Drop & Group UX
+
+## Overview
+
+Allows users to assign lists to groups and reorder lists within groups entirely by drag-and-drop, removing the previous select-box UI. The ungrouped section now also collapses. Empty groups show a drop-zone hint while a drag is in progress so users know they can drop into them.
+
+## Design decisions
+
+- **`dndzone` (full-card drag) rather than `dragHandleZone`** — list cards are larger and less dense than item cards; dragging the whole card feels natural and doesn't require a visible handle icon. Item cards continue to use `dragHandleZone`.
+- **Module-level `isDraggingAny` state** — a single `$state` in `drag.svelte.ts` lets all `ListGroupSection` instances know when any drag is in progress, so they can show/hide empty drop zones without prop drilling or Svelte context.
+- **Finalize-only API calls** — `consider` events only update local preview state; actual API calls (`assignListGroup`, `reorderListInGroup`) are made on `finalize` to avoid hammering the server during a drag.
+- **Removed select boxes** — the `allGroups` prop and `<select>` dropdowns are gone; drag-and-drop is the only assignment mechanism.
+- **Sort order update on every finalize** — after a drop, `reorderListInGroup` is called for any item whose `sortOrderInGroup` differs from its new array index. This keeps server state consistent without a dedicated bulk-reorder endpoint.
+
+## Security considerations
+
+All mutations go through the existing authenticated API client (`authedFetch`). No new endpoints are introduced; this is purely frontend re-plumbing of calls that already exist.
+
+## Implementation plan
+
+1. Create `frontend/src/lib/stores/drag.svelte.ts` — exports `isDraggingAny()` getter and `setDraggingAny(v)` setter backed by module-level `$state`.
+2. Rewrite `ListGroupSection.svelte`:
+   a. Make the ungrouped section collapsible (add button matching the grouped branch).
+   b. Remove `allGroups` prop and `<select>` elements.
+   c. Remove `onlistmove` / `onlistreorder` callbacks (component calls store directly).
+   d. Add `dndItems` local state synced from `sortedLists` when not dragging.
+   e. Wrap list cards in `use:dndzone` with `type: 'list-card'`.
+   f. In `handleConsider`: set local `isDragging = true`, call `setDraggingAny(true)`, update `dndItems`.
+   g. In `handleFinalize`: set `isDragging = false`, call `setDraggingAny(false)`, detect cross-group moves → `assignListGroup`, detect order changes → `reorderListInGroup`.
+   h. Show "Drop here" placeholder when `draggingAny && dndItems.length === 0`.
+3. Update `+page.svelte` — remove `allGroups` prop passing; remove unused `onlistmove`/`onlistreorder` handlers.
+4. Update `ListGroupSection.test.ts` — remove select-related test and `allGroups` prop; add collapse test for ungrouped; add `reorderListInGroup` to store mock.

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -142,12 +142,12 @@ Checkbox-based task list for tracking implementation progress. Tasks are small a
 - [ ] Write integration tests for group CRUD and assign/reorder operations
 
 ### Frontend
-- [ ] Render list index grouped into named collapsible sections; ungrouped lists shown at bottom in a distinct "Ungrouped" section
-- [ ] "Create group" action: name input, calls `POST /api/list-groups`
-- [ ] "Rename group" / "Delete group" actions (per group header menu)
+- [x] Render list index grouped into named collapsible sections; ungrouped lists shown at bottom in a distinct collapsible "Ungrouped" section
+- [x] "Create group" action: name input, calls `POST /api/list-groups`
+- [x] "Rename group" / "Delete group" actions (per group header menu)
 - [ ] Drag-and-drop to reorder groups (calls `PATCH /api/list-groups/{gid}/order`)
-- [ ] Drag-and-drop to move a list into/out of a group and reorder within group (calls `PATCH /api/lists/{id}/group` and `PATCH /api/lists/{id}/group-order`)
-- [ ] Write Vitest component test: list index renders list of lists from mock data
+- [x] Drag-and-drop to move a list into/out of a group and reorder within group (calls `PATCH /api/lists/{id}/group` and `PATCH /api/lists/{id}/group-order`); empty groups show drop zone while dragging
+- [x] Write Vitest component test: list index renders list of lists from mock data
 
 ---
 

--- a/frontend/src/lib/api/lists.ts
+++ b/frontend/src/lib/api/lists.ts
@@ -7,6 +7,8 @@ export interface ListSummaryDto {
 	name: string;
 	emoji: string | null;
 	createdAt: string;
+	groupId: string | null;
+	sortOrderInGroup: number;
 }
 
 export interface ListDto {
@@ -152,4 +154,77 @@ export function updateCategory(
 
 export function deleteCategory(listId: string, categoryId: string): Promise<void> {
 	return authedFetch(`/api/lists/${listId}/categories/${categoryId}`, { method: 'DELETE' });
+}
+
+// ─── List Groups ──────────────────────────────────────────────────────────────
+
+export interface ListGroupDto {
+	id: string;
+	userId: string;
+	name: string;
+	sortOrder: number;
+	createdAt: string;
+}
+
+export interface CreateGroupRequest {
+	name: string;
+}
+
+export interface RenameGroupRequest {
+	name: string;
+}
+
+export interface ReorderGroupRequest {
+	sortOrder: number;
+}
+
+export interface AssignGroupRequest {
+	groupId: string | null;
+}
+
+export interface ReorderInGroupRequest {
+	sortOrder: number;
+}
+
+export function getListGroups(): Promise<ListGroupDto[]> {
+	return authedFetch('/api/list-groups');
+}
+
+export function createListGroup(req: CreateGroupRequest): Promise<ListGroupDto> {
+	return authedFetch('/api/list-groups', {
+		method: 'POST',
+		body: JSON.stringify(req),
+	});
+}
+
+export function renameListGroup(id: string, req: RenameGroupRequest): Promise<ListGroupDto> {
+	return authedFetch(`/api/list-groups/${id}`, {
+		method: 'PUT',
+		body: JSON.stringify(req),
+	});
+}
+
+export function deleteListGroup(id: string): Promise<void> {
+	return authedFetch(`/api/list-groups/${id}`, { method: 'DELETE' });
+}
+
+export function reorderListGroup(id: string, req: ReorderGroupRequest): Promise<ListGroupDto> {
+	return authedFetch(`/api/list-groups/${id}/order`, {
+		method: 'PATCH',
+		body: JSON.stringify(req),
+	});
+}
+
+export function assignListGroup(listId: string, req: AssignGroupRequest): Promise<ListSummaryDto> {
+	return authedFetch(`/api/lists/${listId}/group`, {
+		method: 'PATCH',
+		body: JSON.stringify(req),
+	});
+}
+
+export function reorderListInGroup(listId: string, req: ReorderInGroupRequest): Promise<ListSummaryDto> {
+	return authedFetch(`/api/lists/${listId}/group-order`, {
+		method: 'PATCH',
+		body: JSON.stringify(req),
+	});
 }

--- a/frontend/src/lib/components/ListGroupSection.svelte
+++ b/frontend/src/lib/components/ListGroupSection.svelte
@@ -1,0 +1,186 @@
+<script lang="ts">
+  import type { List, ListGroup } from '$lib/mock-data';
+  import { renameListGroup, deleteListGroup, assignListGroup, reorderListInGroup } from '$lib/stores/lists.svelte';
+  import { isDraggingAny, setDraggingAny } from '$lib/stores/drag.svelte';
+  import { dndzone, SHADOW_ITEM_MARKER_PROPERTY_NAME } from 'svelte-dnd-action';
+  import { friendlyError } from '$lib/api/errors';
+
+  let {
+    group,
+    lists,
+  }: {
+    group: ListGroup | null;
+    lists: List[];
+  } = $props();
+
+  let collapsed = $state(false);
+  let showMenu = $state(false);
+  let renaming = $state(false);
+  let newName = $state('');
+  let error = $state<string | null>(null);
+  let localDragging = $state(false);
+
+  const sortedLists = $derived(lists.slice().sort((a, b) => a.sortOrderInGroup - b.sortOrderInGroup));
+  let dndItems = $state<List[]>([]);
+
+  $effect(() => {
+    if (!localDragging) {
+      dndItems = sortedLists.slice();
+    }
+  });
+
+  const draggingAny = $derived(isDraggingAny());
+
+  function handleConsider(e: CustomEvent<{ items: List[] }>) {
+    if (!localDragging) setDraggingAny(true);
+    localDragging = true;
+    dndItems = e.detail.items;
+  }
+
+  async function handleFinalize(e: CustomEvent<{ items: List[] }>) {
+    localDragging = false;
+    setDraggingAny(false);
+    const newItems = e.detail.items.filter(i => !(i as any)[SHADOW_ITEM_MARKER_PROPERTY_NAME]);
+    dndItems = newItems;
+
+    const currentGroupId = group?.id ?? null;
+
+    for (const item of newItems) {
+      if (item.groupId !== currentGroupId) {
+        try {
+          await assignListGroup(item.id, currentGroupId);
+        } catch (err) {
+          error = friendlyError(err, 'Failed to move list');
+        }
+      }
+    }
+
+    for (let i = 0; i < newItems.length; i++) {
+      if (newItems[i].sortOrderInGroup !== i) {
+        try {
+          await reorderListInGroup(newItems[i].id, i);
+        } catch (err) {
+          error = friendlyError(err, 'Failed to reorder list');
+        }
+      }
+    }
+  }
+
+  async function handleRename() {
+    if (!group || !newName.trim()) return;
+    try {
+      await renameListGroup(group.id, newName.trim());
+      renaming = false;
+      showMenu = false;
+    } catch (e) {
+      error = friendlyError(e, 'Failed to rename group');
+    }
+  }
+
+  async function handleDelete() {
+    if (!group) return;
+    showMenu = false;
+    try {
+      await deleteListGroup(group.id);
+    } catch (e) {
+      error = friendlyError(e, 'Failed to delete group');
+    }
+  }
+</script>
+
+<div class="mb-4">
+  <div class="flex items-center justify-between px-1 mb-2">
+    <button
+      class="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wider text-gray-400 hover:text-gray-500 transition-colors"
+      onclick={() => { collapsed = !collapsed; }}
+      aria-expanded={!collapsed}
+    >
+      <span class="font-normal normal-case tracking-normal">{collapsed ? '▶' : '▼'}</span>
+      {#if group !== null && !renaming}
+        <span>{group.name}</span>
+      {:else if group === null}
+        <span>Ungrouped</span>
+      {/if}
+    </button>
+
+    {#if group !== null}
+      {#if renaming}
+        <div class="flex items-center gap-2 flex-1 ml-2">
+          <input
+            type="text"
+            bind:value={newName}
+            class="flex-1 text-xs border border-gray-300 rounded px-2 py-0.5 focus:outline-none focus:ring-1 focus:ring-blue-400"
+            onkeydown={(e) => { if (e.key === 'Enter') handleRename(); if (e.key === 'Escape') { renaming = false; newName = group?.name ?? ''; } }}
+          />
+          <button onclick={handleRename} class="text-xs text-blue-600 hover:text-blue-700">Save</button>
+          <button onclick={() => { renaming = false; newName = group?.name ?? ''; }} class="text-xs text-gray-400 hover:text-gray-500">Cancel</button>
+        </div>
+      {:else}
+        <div class="relative">
+          <button
+            onclick={(e) => { e.stopPropagation(); showMenu = !showMenu; }}
+            class="p-1 text-gray-300 hover:text-gray-500 transition-colors rounded"
+            aria-label="Group options"
+          >
+            ⋯
+          </button>
+          {#if showMenu}
+            <!-- svelte-ignore a11y_no_static_element_interactions -->
+            <div
+              class="fixed inset-0 z-10"
+              onclick={() => { showMenu = false; }}
+              onkeydown={() => {}}
+            ></div>
+            <div class="absolute right-0 mt-1 z-20 bg-white border border-gray-100 rounded-lg shadow-lg py-1 min-w-[120px]">
+              <button
+                onclick={() => { renaming = true; newName = group?.name ?? ''; showMenu = false; }}
+                class="w-full text-left px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-50"
+              >
+                Rename
+              </button>
+              <button
+                onclick={handleDelete}
+                class="w-full text-left px-3 py-1.5 text-sm text-red-600 hover:bg-gray-50"
+              >
+                Delete
+              </button>
+            </div>
+          {/if}
+        </div>
+      {/if}
+    {/if}
+  </div>
+
+  {#if error}
+    <p class="px-1 mb-2 text-xs text-red-600">{error}</p>
+  {/if}
+
+  {#if !collapsed}
+    <!-- svelte-ignore a11y_no_static_element_interactions -->
+    <div
+      use:dndzone={{ items: dndItems, type: 'list-card', flipDurationMs: 200, dropTargetStyle: {} }}
+      onconsider={handleConsider}
+      onfinalize={handleFinalize}
+      class="space-y-2 min-h-[4px]"
+    >
+      {#if dndItems.length === 0 && draggingAny}
+        <div class="min-h-[52px] border-2 border-dashed border-gray-200 rounded-xl flex items-center justify-center pointer-events-none">
+          <span class="text-xs text-gray-300">Drop here</span>
+        </div>
+      {/if}
+      {#each dndItems as list (list.id)}
+        <div
+          class="flex items-center gap-4 p-4 bg-white rounded-xl border border-gray-100 hover:border-gray-200 hover:shadow-sm transition-all cursor-grab active:cursor-grabbing {(list as any)[SHADOW_ITEM_MARKER_PROPERTY_NAME] ? 'opacity-40' : ''}"
+        >
+          <a href="/lists/{list.id}" class="flex items-center gap-4 flex-1 min-w-0" draggable="false">
+            <span class="text-3xl">{list.emoji ?? '📋'}</span>
+            <div class="flex-1 min-w-0">
+              <h2 class="font-semibold text-gray-900">{list.name}</h2>
+            </div>
+            <span class="text-gray-300">›</span>
+          </a>
+        </div>
+      {/each}
+    </div>
+  {/if}
+</div>

--- a/frontend/src/lib/components/ListGroupSection.svelte
+++ b/frontend/src/lib/components/ListGroupSection.svelte
@@ -2,7 +2,7 @@
   import type { List, ListGroup } from '$lib/mock-data';
   import { renameListGroup, deleteListGroup, assignListGroup, reorderListInGroup } from '$lib/stores/lists.svelte';
   import { isDraggingAny, setDraggingAny } from '$lib/stores/drag.svelte';
-  import { dndzone, SHADOW_ITEM_MARKER_PROPERTY_NAME } from 'svelte-dnd-action';
+  import { dragHandleZone, dragHandle, SHADOW_ITEM_MARKER_PROPERTY_NAME } from 'svelte-dnd-action';
   import { friendlyError } from '$lib/api/errors';
 
   let {
@@ -158,7 +158,7 @@
   {#if !collapsed}
     <!-- svelte-ignore a11y_no_static_element_interactions -->
     <div
-      use:dndzone={{ items: dndItems, type: 'list-card', flipDurationMs: 200, dropTargetStyle: {} }}
+      use:dragHandleZone={{ items: dndItems, type: 'list-card', flipDurationMs: 200, dropTargetStyle: {} }}
       onconsider={handleConsider}
       onfinalize={handleFinalize}
       class="space-y-2 min-h-[4px]"
@@ -170,9 +170,21 @@
       {/if}
       {#each dndItems as list (list.id)}
         <div
-          class="flex items-center gap-4 p-4 bg-white rounded-xl border border-gray-100 hover:border-gray-200 hover:shadow-sm transition-all cursor-grab active:cursor-grabbing {(list as any)[SHADOW_ITEM_MARKER_PROPERTY_NAME] ? 'opacity-40' : ''}"
+          class="flex items-center gap-4 p-4 bg-white rounded-xl border border-gray-100 hover:border-gray-200 hover:shadow-sm transition-all {(list as any)[SHADOW_ITEM_MARKER_PROPERTY_NAME] ? 'opacity-40' : ''}"
         >
-          <a href="/lists/{list.id}" class="flex items-center gap-4 flex-1 min-w-0" draggable="false">
+          <div
+            use:dragHandle
+            class="flex-shrink-0 flex items-center justify-center w-5 self-center cursor-grab active:cursor-grabbing touch-none text-gray-300 hover:text-gray-400"
+            aria-label="Drag to reorder"
+            tabindex="-1"
+          >
+            <svg width="10" height="16" viewBox="0 0 10 16" fill="currentColor" aria-hidden="true">
+              <circle cx="3" cy="3" r="1.5"/><circle cx="7" cy="3" r="1.5"/>
+              <circle cx="3" cy="8" r="1.5"/><circle cx="7" cy="8" r="1.5"/>
+              <circle cx="3" cy="13" r="1.5"/><circle cx="7" cy="13" r="1.5"/>
+            </svg>
+          </div>
+          <a href="/lists/{list.id}" class="flex items-center gap-4 flex-1 min-w-0" draggable="false" oncontextmenu={(e) => e.preventDefault()}>
             <span class="text-3xl">{list.emoji ?? '📋'}</span>
             <div class="flex-1 min-w-0">
               <h2 class="font-semibold text-gray-900">{list.name}</h2>

--- a/frontend/src/lib/components/ListGroupSection.test.ts
+++ b/frontend/src/lib/components/ListGroupSection.test.ts
@@ -1,0 +1,107 @@
+import { render, fireEvent } from '@testing-library/svelte';
+import { describe, it, expect, vi } from 'vitest';
+import ListGroupSection from './ListGroupSection.svelte';
+import type { List, ListGroup } from '$lib/mock-data';
+
+vi.mock('$lib/stores/lists.svelte', () => ({
+  renameListGroup: vi.fn(),
+  deleteListGroup: vi.fn(),
+  assignListGroup: vi.fn(),
+  reorderListInGroup: vi.fn(),
+}));
+
+vi.mock('$lib/stores/drag.svelte', () => ({
+  isDraggingAny: vi.fn(() => false),
+  setDraggingAny: vi.fn(),
+}));
+
+const group: ListGroup = {
+  id: 'group-home',
+  userId: 'u1',
+  name: 'Home',
+  sortOrder: 0,
+  createdAt: '2024-01-01T00:00:00Z',
+};
+
+const lists: List[] = [
+  {
+    id: 'grocery',
+    name: 'Grocery',
+    emoji: '🛒',
+    description: null,
+    defaultSortField: 'MANUAL',
+    defaultSortDirection: 'ASC',
+    createdAt: '2024-01-01T00:00:00Z',
+    groupId: 'group-home',
+    sortOrderInGroup: 0,
+  },
+  {
+    id: 'household',
+    name: 'Household',
+    emoji: '🏠',
+    description: null,
+    defaultSortField: 'DUE_DATE',
+    defaultSortDirection: 'ASC',
+    createdAt: '2024-01-01T00:00:00Z',
+    groupId: 'group-home',
+    sortOrderInGroup: 1,
+  },
+];
+
+describe('ListGroupSection', () => {
+  it('renders group name', () => {
+    const { getAllByText } = render(ListGroupSection, { props: { group, lists } });
+    expect(getAllByText('Home').length).toBeGreaterThan(0);
+  });
+
+  it('renders lists within the group', () => {
+    const { getByText } = render(ListGroupSection, { props: { group, lists } });
+    expect(getByText('Grocery')).toBeTruthy();
+    expect(getByText('Household')).toBeTruthy();
+  });
+
+  it('renders lists in sortOrderInGroup order', () => {
+    const { container } = render(ListGroupSection, { props: { group, lists } });
+    const anchors = container.querySelectorAll('a[href]');
+    const hrefs = Array.from(anchors).map(a => a.getAttribute('href'));
+    expect(hrefs[0]).toBe('/lists/grocery');
+    expect(hrefs[1]).toBe('/lists/household');
+  });
+
+  it('renders ungrouped section label when group is null', () => {
+    const ungrouped: List[] = [
+      {
+        id: 'personal',
+        name: 'Personal',
+        emoji: '📋',
+        description: null,
+        defaultSortField: 'STARRED',
+        defaultSortDirection: 'DESC',
+        createdAt: '2024-01-01T00:00:00Z',
+        groupId: null,
+        sortOrderInGroup: 0,
+      },
+    ];
+    const { getAllByText, getByText } = render(ListGroupSection, { props: { group: null, lists: ungrouped } });
+    expect(getAllByText('Ungrouped').length).toBeGreaterThan(0);
+    expect(getByText('Personal')).toBeTruthy();
+  });
+
+  it('ungrouped section is collapsible', async () => {
+    const { container, getByRole } = render(ListGroupSection, { props: { group: null, lists } });
+    // Initially expanded
+    expect(container.querySelectorAll('a[href]').length).toBe(lists.length);
+    // Collapse
+    const toggleBtn = getByRole('button', { name: /ungrouped/i });
+    await fireEvent.click(toggleBtn);
+    expect(container.querySelectorAll('a[href]').length).toBe(0);
+  });
+
+  it('grouped section is collapsible', async () => {
+    const { container, getByRole } = render(ListGroupSection, { props: { group, lists } });
+    expect(container.querySelectorAll('a[href]').length).toBe(lists.length);
+    const toggleBtn = getByRole('button', { name: /home/i });
+    await fireEvent.click(toggleBtn);
+    expect(container.querySelectorAll('a[href]').length).toBe(0);
+  });
+});

--- a/frontend/src/lib/components/ListGroupSection.test.ts
+++ b/frontend/src/lib/components/ListGroupSection.test.ts
@@ -15,6 +15,14 @@ vi.mock('$lib/stores/drag.svelte', () => ({
   setDraggingAny: vi.fn(),
 }));
 
+vi.mock('svelte-dnd-action', () => ({
+  dragHandleZone: (_node: HTMLElement, _options: Record<string, unknown>) => {
+    return { update: () => {}, destroy: () => {} };
+  },
+  dragHandle: () => ({ destroy: () => {} }),
+  SHADOW_ITEM_MARKER_PROPERTY_NAME: '__shadow__',
+}));
+
 const group: ListGroup = {
   id: 'group-home',
   userId: 'u1',
@@ -49,6 +57,20 @@ const lists: List[] = [
 ];
 
 describe('ListGroupSection', () => {
+  it('each list card renders a drag handle for touch-friendly dragging', () => {
+    const { container } = render(ListGroupSection, { props: { group, lists } });
+    const handles = container.querySelectorAll('[aria-label="Drag to reorder"]');
+    expect(handles.length).toBe(lists.length);
+  });
+
+  it('long-press on list card anchor does not show browser link preview (contextmenu suppressed)', () => {
+    const { container } = render(ListGroupSection, { props: { group, lists } });
+    const anchor = container.querySelector('a[href]') as HTMLAnchorElement;
+    const event = new MouseEvent('contextmenu', { bubbles: true, cancelable: true });
+    anchor.dispatchEvent(event);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
   it('renders group name', () => {
     const { getAllByText } = render(ListGroupSection, { props: { group, lists } });
     expect(getAllByText('Home').length).toBeGreaterThan(0);

--- a/frontend/src/lib/mock-data.ts
+++ b/frontend/src/lib/mock-data.ts
@@ -22,6 +22,16 @@ export interface List {
   defaultSortField: SortField;
   defaultSortDirection: SortDirection;
   createdAt: string;
+  groupId: string | null;
+  sortOrderInGroup: number;
+}
+
+export interface ListGroup {
+  id: string;
+  userId: string;
+  name: string;
+  sortOrder: number;
+  createdAt: string;
 }
 
 export interface Category {
@@ -54,10 +64,15 @@ export const mockUsers: User[] = [
   { id: 'u2', name: 'Anna', email: 'anna@example.com' }
 ];
 
+export const mockListGroups: ListGroup[] = [
+  { id: 'group-home', userId: 'u1', name: 'Home', sortOrder: 0, createdAt: '2024-01-01T00:00:00Z' },
+  { id: 'group-work', userId: 'u1', name: 'Work', sortOrder: 1, createdAt: '2024-01-01T00:00:00Z' },
+];
+
 export const mockLists: List[] = [
-  { id: 'grocery', name: 'Grocery', emoji: '🛒', description: null, defaultSortField: 'MANUAL', defaultSortDirection: 'ASC', createdAt: '2024-01-01T00:00:00Z' },
-  { id: 'household', name: 'Household', emoji: '🏠', description: null, defaultSortField: 'DUE_DATE', defaultSortDirection: 'ASC', createdAt: '2024-01-01T00:00:00Z' },
-  { id: 'personal', name: 'Personal', emoji: '📋', description: null, defaultSortField: 'STARRED', defaultSortDirection: 'DESC', createdAt: '2024-01-01T00:00:00Z' }
+  { id: 'grocery', name: 'Grocery', emoji: '🛒', description: null, defaultSortField: 'MANUAL', defaultSortDirection: 'ASC', createdAt: '2024-01-01T00:00:00Z', groupId: 'group-home', sortOrderInGroup: 0 },
+  { id: 'household', name: 'Household', emoji: '🏠', description: null, defaultSortField: 'DUE_DATE', defaultSortDirection: 'ASC', createdAt: '2024-01-01T00:00:00Z', groupId: 'group-home', sortOrderInGroup: 1 },
+  { id: 'personal', name: 'Personal', emoji: '📋', description: null, defaultSortField: 'STARRED', defaultSortDirection: 'DESC', createdAt: '2024-01-01T00:00:00Z', groupId: null, sortOrderInGroup: 0 }
 ];
 
 export const mockCategories: Category[] = [

--- a/frontend/src/lib/stores/drag.svelte.ts
+++ b/frontend/src/lib/stores/drag.svelte.ts
@@ -1,0 +1,9 @@
+let _isDraggingAny = $state(false);
+
+export function isDraggingAny(): boolean {
+	return _isDraggingAny;
+}
+
+export function setDraggingAny(value: boolean): void {
+	_isDraggingAny = value;
+}

--- a/frontend/src/lib/stores/lists.svelte.ts
+++ b/frontend/src/lib/stores/lists.svelte.ts
@@ -1,4 +1,4 @@
-import type { List, Category, SortField, SortDirection } from '$lib/mock-data';
+import type { List, ListGroup, Category, SortField, SortDirection } from '$lib/mock-data';
 import {
 	getLists as apiGetLists,
 	createList as apiCreateList,
@@ -8,11 +8,19 @@ import {
 	createCategory as apiCreateCategory,
 	updateCategory as apiUpdateCategory,
 	deleteCategory as apiDeleteCategory,
+	getListGroups as apiGetListGroups,
+	createListGroup as apiCreateListGroup,
+	renameListGroup as apiRenameListGroup,
+	deleteListGroup as apiDeleteListGroup,
+	reorderListGroup as apiReorderListGroup,
+	assignListGroup as apiAssignListGroup,
+	reorderListInGroup as apiReorderListInGroup,
 	type CreateListRequest,
 	type UpdateListRequest,
 } from '$lib/api/lists';
 
 let lists = $state<List[]>([]);
+let listGroups = $state<ListGroup[]>([]);
 let categories = $state<Category[]>([]);
 let hideDoneMap = $state<Map<string, boolean>>(new Map());
 let loading = $state(false);
@@ -33,6 +41,10 @@ export function getLists(): List[] {
   return lists;
 }
 
+export function getListGroups(): ListGroup[] {
+  return listGroups;
+}
+
 export function getList(id: string): List | undefined {
   return lists.find(l => l.id === id);
 }
@@ -40,7 +52,7 @@ export function getList(id: string): List | undefined {
 export async function loadLists(fetchFn: typeof fetch = fetch): Promise<void> {
   loading = true;
   try {
-    const dtos = await apiGetLists(fetchFn);
+    const [dtos, groupDtos] = await Promise.all([apiGetLists(fetchFn), apiGetListGroups()]);
     lists = dtos.map(dto => ({
       id: dto.id,
       name: dto.name,
@@ -48,6 +60,15 @@ export async function loadLists(fetchFn: typeof fetch = fetch): Promise<void> {
       description: null,
       defaultSortField: 'MANUAL' as SortField,
       defaultSortDirection: 'ASC' as SortDirection,
+      createdAt: dto.createdAt,
+      groupId: dto.groupId,
+      sortOrderInGroup: dto.sortOrderInGroup,
+    }));
+    listGroups = groupDtos.map(dto => ({
+      id: dto.id,
+      userId: dto.userId,
+      name: dto.name,
+      sortOrder: dto.sortOrder,
       createdAt: dto.createdAt,
     }));
   } finally {
@@ -65,13 +86,57 @@ export async function createList(req: CreateListRequest): Promise<List> {
     defaultSortField: dto.defaultSortField as SortField,
     defaultSortDirection: dto.defaultSortDirection as SortDirection,
     createdAt: dto.createdAt,
+    groupId: null,
+    sortOrderInGroup: 0,
   };
   lists.push(list);
   return list;
 }
 
+// ─── List Group operations ────────────────────────────────────────────────────
+
+export async function createListGroup(name: string): Promise<ListGroup> {
+  const dto = await apiCreateListGroup({ name });
+  const group: ListGroup = { id: dto.id, userId: dto.userId, name: dto.name, sortOrder: dto.sortOrder, createdAt: dto.createdAt };
+  listGroups.push(group);
+  return group;
+}
+
+export async function renameListGroup(id: string, name: string): Promise<void> {
+  const dto = await apiRenameListGroup(id, { name });
+  const idx = listGroups.findIndex(g => g.id === id);
+  if (idx >= 0) listGroups[idx] = { ...listGroups[idx], name: dto.name };
+}
+
+export async function deleteListGroup(id: string): Promise<void> {
+  await apiDeleteListGroup(id);
+  const idx = listGroups.findIndex(g => g.id === id);
+  if (idx >= 0) listGroups.splice(idx, 1);
+  // Clear groupId on all affected lists in store
+  lists.forEach((l, i) => { if (l.groupId === id) lists[i] = { ...l, groupId: null }; });
+}
+
+export async function reorderListGroup(id: string, sortOrder: number): Promise<void> {
+  await apiReorderListGroup(id, { sortOrder });
+  const idx = listGroups.findIndex(g => g.id === id);
+  if (idx >= 0) listGroups[idx] = { ...listGroups[idx], sortOrder };
+}
+
+export async function assignListGroup(listId: string, groupId: string | null): Promise<void> {
+  await apiAssignListGroup(listId, { groupId });
+  const idx = lists.findIndex(l => l.id === listId);
+  if (idx >= 0) lists[idx] = { ...lists[idx], groupId };
+}
+
+export async function reorderListInGroup(listId: string, sortOrder: number): Promise<void> {
+  await apiReorderListInGroup(listId, { sortOrder });
+  const idx = lists.findIndex(l => l.id === listId);
+  if (idx >= 0) lists[idx] = { ...lists[idx], sortOrderInGroup: sortOrder };
+}
+
 export async function updateList(id: string, req: UpdateListRequest): Promise<List> {
   const dto = await apiUpdateList(id, req);
+  const existing = lists.find(l => l.id === id);
   const list: List = {
     id: dto.id,
     name: dto.name,
@@ -80,6 +145,8 @@ export async function updateList(id: string, req: UpdateListRequest): Promise<Li
     defaultSortField: dto.defaultSortField as SortField,
     defaultSortDirection: dto.defaultSortDirection as SortDirection,
     createdAt: dto.createdAt,
+    groupId: existing?.groupId ?? null,
+    sortOrderInGroup: existing?.sortOrderInGroup ?? 0,
   };
   const idx = lists.findIndex(l => l.id === id);
   if (idx >= 0) lists[idx] = list;

--- a/frontend/src/routes/(app)/lists/+page.svelte
+++ b/frontend/src/routes/(app)/lists/+page.svelte
@@ -1,14 +1,24 @@
 <script lang="ts">
   import { goto } from '$app/navigation';
-  import { getLists, createList, isLoading } from '$lib/stores/lists.svelte';
+  import { getLists, getListGroups, createList, createListGroup, isLoading } from '$lib/stores/lists.svelte';
+  import { isDraggingAny } from '$lib/stores/drag.svelte';
   import ListForm from '$lib/components/ListForm.svelte';
+  import ListGroupSection from '$lib/components/ListGroupSection.svelte';
   import { friendlyError } from '$lib/api/errors';
 
   const lists = $derived(getLists());
+  const groups = $derived(getListGroups());
+  const draggingAny = $derived(isDraggingAny());
+
+  const sortedGroups = $derived(groups.slice().sort((a, b) => a.sortOrder - b.sortOrder));
+  const ungroupedLists = $derived(lists.filter(l => l.groupId === null));
 
   let showAddForm = $state(false);
   let saving = $state(false);
   let error = $state<string | null>(null);
+  let addingGroup = $state(false);
+  let newGroupName = $state('');
+  let groupError = $state<string | null>(null);
 
   async function handleSave({ name, emoji }: { name: string; emoji: string }) {
     saving = true;
@@ -23,6 +33,18 @@
       saving = false;
     }
   }
+
+  async function handleAddGroup() {
+    if (!newGroupName.trim()) return;
+    groupError = null;
+    try {
+      await createListGroup(newGroupName.trim());
+      newGroupName = '';
+      addingGroup = false;
+    } catch (e) {
+      groupError = friendlyError(e, 'Failed to create group');
+    }
+  }
 </script>
 
 <div class="pb-20">
@@ -33,19 +55,20 @@
       {/each}
     </div>
   {:else}
-    <div class="grid gap-3">
-      {#each lists as list (list.id)}
-        <a
-          href="/lists/{list.id}"
-          class="flex items-center gap-4 p-4 bg-white rounded-xl border border-gray-100 hover:border-gray-200 hover:shadow-sm transition-all"
-        >
-          <span class="text-3xl">{list.emoji ?? '📋'}</span>
-          <div class="flex-1">
-            <h2 class="font-semibold text-gray-900">{list.name}</h2>
-          </div>
-          <span class="text-gray-300">›</span>
-        </a>
+    <div class="space-y-2">
+      {#each sortedGroups as group (group.id)}
+        <ListGroupSection
+          {group}
+          lists={lists.filter(l => l.groupId === group.id)}
+        />
       {/each}
+
+      {#if ungroupedLists.length > 0 || draggingAny}
+        <ListGroupSection
+          group={null}
+          lists={ungroupedLists}
+        />
+      {/if}
     </div>
   {/if}
 </div>
@@ -59,14 +82,47 @@
           oncancel={() => { showAddForm = false; error = null; }}
         />
       </div>
+    {:else if addingGroup}
+      <div class="flex gap-2">
+        <input
+          type="text"
+          bind:value={newGroupName}
+          placeholder="Group name"
+          class="flex-1 border border-gray-300 rounded-xl px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-400"
+          onkeydown={(e) => { if (e.key === 'Enter') handleAddGroup(); if (e.key === 'Escape') { addingGroup = false; newGroupName = ''; } }}
+        />
+        <button
+          onclick={handleAddGroup}
+          class="px-4 py-2 text-sm bg-blue-600 text-white rounded-xl hover:bg-blue-700 transition-colors"
+        >
+          Add
+        </button>
+        <button
+          onclick={() => { addingGroup = false; newGroupName = ''; groupError = null; }}
+          class="px-4 py-2 text-sm text-gray-400 hover:text-gray-500 transition-colors"
+        >
+          Cancel
+        </button>
+      </div>
+      {#if groupError}
+        <p class="mt-2 text-sm text-red-600">{groupError}</p>
+      {/if}
     {:else}
-      <button
-        onclick={() => { showAddForm = true; }}
-        disabled={saving}
-        class="w-full py-3 border-2 border-dashed border-gray-200 rounded-xl text-sm text-gray-400 hover:border-gray-300 hover:text-gray-500 transition-colors disabled:opacity-50"
-      >
-        + New list
-      </button>
+      <div class="flex gap-2">
+        <button
+          onclick={() => { showAddForm = true; }}
+          disabled={saving}
+          class="flex-1 py-3 border-2 border-dashed border-gray-200 rounded-xl text-sm text-gray-400 hover:border-gray-300 hover:text-gray-500 transition-colors disabled:opacity-50"
+        >
+          + New list
+        </button>
+        <button
+          onclick={() => { addingGroup = true; }}
+          class="py-3 px-4 border-2 border-dashed border-gray-200 rounded-xl text-sm text-gray-400 hover:border-gray-300 hover:text-gray-500 transition-colors"
+        >
+          + New group
+        </button>
+      </div>
     {/if}
     {#if error}
       <p class="mt-2 text-sm text-red-600">{error}</p>


### PR DESCRIPTION
## Summary

- **Backend**: `ListGroup` entity + full CRUD (`GET/POST /api/list-groups`, `PUT/DELETE/PATCH /api/list-groups/{gid}`, `PATCH /api/lists/{id}/group`, `PATCH /api/lists/{id}/group-order`); fixes `ClassCastException` on second group creation by replacing derived `findMaxSortOrderByUserId` with an explicit `@Query`
- **Frontend**: Collapsible group sections (including Ungrouped); drag-and-drop to move lists between groups and reorder within groups using `svelte-dnd-action`; empty groups show a drop-zone hint while dragging; removed the ugly select-box assignment UI; global `drag.svelte.ts` store tracks drag state across sections
- **Tests**: Backend integration tests for all group endpoints; frontend Vitest tests for collapse behaviour and updated DnD mocks

## Test plan

- [ ] `./gradlew test --tests "com.github.matthiasbalke.todo.lists.ListGroupIntegrationTest"` — all integration tests green
- [ ] `bun run test --run` in `frontend/` — 100 tests green
- [ ] `bun run check` in `frontend/` — no type errors
- [ ] Manual: create two groups, drag lists between them, verify order persists on reload
- [ ] Manual: drag a list into an empty group, verify drop-zone hint appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)