### PR TITLE
ci: reuse built Docker images in E2E job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,19 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           context: backend
+          tags: todo/backend:ci
+          outputs: type=docker,dest=/tmp/backend.tar
           build-args: |
             BUILD_NUMBER=${{ github.run_number }}
           cache-from: type=gha,scope=backend
           cache-to: ${{ github.event_name == 'push' && 'type=gha,mode=max,scope=backend' || '' }}
+
+      - name: Upload backend image artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: backend-image
+          path: /tmp/backend.tar
+          retention-days: 1
 
   build-frontend:
     name: Build frontend image
@@ -36,10 +45,19 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           context: frontend
+          tags: todo/frontend:ci
+          outputs: type=docker,dest=/tmp/frontend.tar
           build-args: |
             BUILD_NUMBER=${{ github.run_number }}
           cache-from: type=gha,scope=frontend
           cache-to: ${{ github.event_name == 'push' && 'type=gha,mode=max,scope=frontend' || '' }}
+
+      - name: Upload frontend image artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: frontend-image
+          path: /tmp/frontend.tar
+          retention-days: 1
 
   test-backend:
     name: Test backend
@@ -89,29 +107,35 @@ jobs:
         working-directory: frontend
 
   e2e:
-    needs: [build-backend]
+    needs: [build-backend, build-frontend]
     name: Playwright
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
 
-      - uses: docker/setup-buildx-action@v4
-
-      # otherwise we get an authentication error wenn pulling using docker-compose
+      # otherwise we get an authentication error when pulling using docker-compose
       - name: Pre-pull backend-healthcheck image
-        run: echo 'FROM dhi.io/curl:8.14.1-dev' | docker buildx build --load -t dhi.io/curl:8.14.1-dev -
+        run: echo 'FROM dhi.io/curl:8.14.1-dev' | docker build -t dhi.io/curl:8.14.1-dev -
 
-      - name: Build backend image
-        uses: docker/build-push-action@v7
+      - name: Download backend image
+        uses: actions/download-artifact@v4
         with:
-          context: backend
-          load: true
-          build-args: |
-            BUILD_NUMBER=${{ github.run_number }}
-          cache-from: type=gha,scope=backend
+          name: backend-image
+          path: /tmp
 
-      - name: Start postgres and backend
-        run: docker compose up postgres backend backend-healthcheck frontend nginx --wait -d
+      - name: Download frontend image
+        uses: actions/download-artifact@v4
+        with:
+          name: frontend-image
+          path: /tmp
+
+      - name: Load Docker images
+        run: |
+          docker load < /tmp/backend.tar
+          docker load < /tmp/frontend.tar
+
+      - name: Start services
+        run: docker compose up postgres backend backend-healthcheck frontend nginx --no-build --wait -d
 
       - uses: oven-sh/setup-bun@v2
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       retries: 10
 
   backend:
+    image: todo/backend:ci
     build: ./backend
     ports:
       - "8080:8080"
@@ -46,6 +47,7 @@ services:
         condition: service_started
 
   frontend:
+    image: todo/frontend:ci
     build: ./frontend
     ports:
       - "3000:3000"


### PR DESCRIPTION
## Summary

- Export backend and frontend Docker images as tar artifacts during their respective build jobs
- Download and `docker load` those artifacts in the E2E job instead of rebuilding from scratch
- Add stable `image:` names (`todo/backend:ci`, `todo/frontend:ci`) to `docker-compose.yml` so Compose uses the pre-loaded images and skips builds
- E2E job now correctly depends on both `build-backend` and `build-frontend`

## Test plan

- [ ] Push to a branch and confirm `build-backend` and `build-frontend` each upload an artifact visible in the Actions run summary
- [ ] Confirm `e2e` only starts after both build jobs complete (dependency graph)
- [ ] Confirm `e2e` has no "Build backend image" step and no buildx setup
- [ ] Confirm `docker compose up` output contains no "Building backend" / "Building frontend" lines
- [ ] Confirm E2E tests pass end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)