### PR TITLE
ci: reduce Docker BuildKit GHA cache size

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           build-args: |
             BUILD_NUMBER=${{ github.run_number }}
           cache-from: type=gha,scope=backend
-          cache-to: ${{ github.event_name == 'push' && 'type=gha,mode=max,scope=backend' || '' }}
+          cache-to: ${{ github.event_name == 'push' && 'type=gha,mode=min,scope=backend' || '' }}
 
       - name: Upload backend image artifact
         uses: actions/upload-artifact@v7
@@ -50,7 +50,7 @@ jobs:
           build-args: |
             BUILD_NUMBER=${{ github.run_number }}
           cache-from: type=gha,scope=frontend
-          cache-to: ${{ github.event_name == 'push' && 'type=gha,mode=max,scope=frontend' || '' }}
+          cache-to: ${{ github.event_name == 'push' && 'type=gha,mode=min,scope=frontend' || '' }}
 
       - name: Upload frontend image artifact
         uses: actions/upload-artifact@v7

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,7 +1,8 @@
 FROM dhi.io/gradle:9.4.1-r1-jdk21-alpine3.23-dev AS build
 WORKDIR /app
 COPY . .
-RUN gradle bootJar --no-daemon -Prelease
+RUN --mount=type=cache,id=gradle,target=/root/.gradle \
+    gradle bootJar --no-daemon -Prelease
 
 FROM dhi.io/eclipse-temurin:21-alpine3.22
 WORKDIR /app

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,7 +1,8 @@
 FROM dhi.io/bun:1.3.11-alpine3.22-dev AS build
 WORKDIR /app
 COPY package.json bun.lockb ./
-RUN bun install --frozen-lockfile
+RUN --mount=type=cache,id=bun,target=/root/.bun/install/cache \
+    bun install --frozen-lockfile
 COPY . .
 RUN bun run build
 


### PR DESCRIPTION
## Summary

- Switch `cache-to` from `mode=max` to `mode=min` in both `build-backend` and `build-frontend` jobs — only final image layers are exported to GHA cache instead of all intermediate build stages
- Add BuildKit cache mounts (`--mount=type=cache`) for Gradle deps (`/root/.gradle`) and bun packages (`/root/.bun/install/cache`) so dependencies are not re-downloaded on every run despite `mode=min`

**Expected GHA cache reduction:** ~5–6 GB → ~500–800 MB for Docker layer caches, plus ~200–400 MB for the two dependency cache mounts.

## Test plan

- [ ] Confirm `build-backend` and `build-frontend` jobs succeed and upload image artifacts
- [ ] Confirm E2E tests pass end-to-end
- [ ] Check `github.com/<repo>/actions/caches` — `backend` and `frontend` Docker scopes should be significantly smaller after the first push to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)