### PR TITLE
Fix CORS configuration to accept origins without default ports

### DIFF
--- a/.claude/commands/bugfix.md
+++ b/.claude/commands/bugfix.md
@@ -1,0 +1,98 @@
+Fix a bug using a strict TDD workflow: write failing tests first, then fix, then verify. No scope creep.
+
+## Usage
+
+`/bugfix <description>` — fix the described bug
+`/bugfix` — describe the bug interactively
+
+## Workflow
+
+**If no description was provided**, ask the user: "What bug should I fix? Please describe the symptom, where it occurs, and any relevant error messages or reproduction steps."
+
+Once you have a clear bug description, follow these steps **in strict order**:
+
+---
+
+### Step 1 — Understand the bug
+
+- Read the relevant source files to understand the affected code paths.
+- Identify the root cause (or the most likely candidate if not yet confirmed).
+- Identify which layer is affected: backend (Kotlin/Gradle), frontend (SvelteKit/bun), or both.
+
+---
+
+### Step 2 — Write failing test(s) BEFORE touching production code
+
+Write one or more tests that reproduce the bug:
+
+- **Backend:** add tests to the appropriate test class under `backend/src/test/`. Use `AbstractIntegrationTest` for tests that need a real PostgreSQL instance (Testcontainers). Unit tests are preferred when the bug is in pure logic.
+- **Frontend:** add Vitest tests under `frontend/src/` near the affected module.
+- **E2E (last resort):** only add Playwright tests in `e2e/` if the bug cannot be reproduced at a lower level.
+
+The test must:
+- Directly describe the bug symptom in its name (e.g., `"should not promote last owner when only one owner remains"`)
+- Fail with the current (unfixed) code — this proves the test is meaningful
+
+---
+
+### Step 3 — Run the new test(s) to confirm they fail
+
+**Backend:**
+```bash
+./gradlew test --tests "FullClassName"
+```
+
+**Frontend:**
+```bash
+bun run test --reporter=verbose <path-to-test-file>
+```
+
+**E2E:**
+```bash
+bunx playwright test <spec-file>
+```
+
+If the test **passes** before the fix, stop and reassess — either the test does not reproduce the bug, or the bug was already fixed elsewhere. Investigate and correct the test before continuing.
+
+---
+
+### Step 4 — Implement the fix
+
+- Make the **minimum code changes** required to fix the bug.
+- **Do not** change formatting, style, naming, or anything unrelated to the bug.
+- **Do not** refactor surrounding code, even if it looks like it could be improved.
+- **Do not** add features or handle edge cases not described in the bug report.
+- If you notice unrelated issues while fixing, note them in your final report but do not touch them.
+
+---
+
+### Step 5 — Run all tests
+
+**Backend:**
+```bash
+./gradlew test
+```
+
+**Frontend:**
+```bash
+bun run test
+```
+
+**E2E (only if E2E tests were added or the bug was UI-level):**
+```bash
+bunx playwright test
+```
+
+All tests must pass. If a pre-existing test fails, investigate before concluding the fix is correct — do not suppress or skip failing tests.
+
+---
+
+### Step 6 — Report
+
+Summarize:
+1. **Root cause** — what was wrong and why
+2. **Tests added** — file path(s) and test name(s)
+3. **Production code changed** — file path(s) and what changed (one sentence per change)
+4. **Explicitly left unchanged** — anything you noticed but deliberately did not touch
+
+Keep the report concise. No padding.

--- a/.claude/commands/cleanup-pr.md
+++ b/.claude/commands/cleanup-pr.md
@@ -1,0 +1,55 @@
+You are helping the user clean up a noisy PR branch by rewriting its history into clean, logical commits using a safe backup-first workflow.
+
+## Step 1 — Gather context
+
+Run these commands in parallel:
+- `git branch --show-current` — get the current branch name
+- `git log --oneline origin/main..HEAD` — show the noisy commit history
+- `git diff --stat origin/main..HEAD` — show what files actually changed
+
+Present the log and diff-stat to the user so they can see what needs cleaning up.
+
+## Step 2 — Create & push backup branch
+
+- Create a backup branch: `git branch backup/<current-branch>`
+- Push it: `git push origin backup/<current-branch>`
+
+**The push must succeed before continuing.** If the push fails, stop and report the error. Do not touch the PR branch.
+
+Confirm to the user that the backup is safe on the remote at `backup/<current-branch>`.
+
+## Step 3 — Plan clean history with user
+
+Show the diff-stat from Step 1 again for reference. Then use AskUserQuestion to ask the user to describe the desired clean commits. For each commit they want, you need:
+- The commit message
+- Which files (or source SHAs) should be included in that commit
+
+Wait for the user's answer before proceeding.
+
+## Step 4 — Rebase
+
+Execute the rebase plan:
+
+1. `git reset --hard origin/main` — reset branch to main
+2. For each planned commit in order:
+    - Stage the relevant files: `git checkout <sha> -- <file1> <file2> ...`
+      (use the original HEAD SHA from before the reset to restore file contents)
+    - Commit: `git commit -m "<message>"`
+
+## Step 5 — Verify
+
+Run in parallel:
+- `git log --oneline origin/main..HEAD` — confirm commit count and messages match the plan
+- `git diff --name-only origin/main..HEAD` — confirm the right files are included
+
+Present both outputs to the user and ask them to confirm it looks correct before force-pushing.
+
+## Step 6 — Force-push
+
+1. Refresh the tracking ref: `git fetch origin <branch>`
+2. Force-push with lease: `git push --force-with-lease`
+
+If `--force-with-lease` fails with a "stale" or "rejected" error, tell the user:
+> The tracking ref is stale even after fetch. Run `git push --force` manually to complete the push. This is safe because you verified the backup is on the remote at `backup/<current-branch>`.
+
+Do **not** run `git push --force` automatically — let the user decide.

--- a/.claude/commands/feature.md
+++ b/.claude/commands/feature.md
@@ -1,0 +1,103 @@
+You are acting as a Senior Software Engineer. Your task is to plan and implement the feature: **$ARGUMENTS**
+
+## Step 1 — Understand the context
+
+Before writing a single line of code, read and internalize:
+- `docs/requirements.md` — what the product needs to do
+- `docs/security.md` — security requirements and constraints
+- `CLAUDE.md` — tech stack, architecture decisions, and conventions
+- Any existing feature docs in `docs/features/` that are related
+
+## Step 2 — Design a good solution
+
+Think carefully. Don't just pick the first solution that comes to mind. Ask yourself:
+- Does this approach satisfy all relevant requirements in `docs/requirements.md`?
+- Does it meet the security constraints in `docs/security.md`?
+- Is it consistent with the existing architecture decisions in `CLAUDE.md`?
+- Is it the simplest solution that fully solves the problem?
+- What are the edge cases and failure modes?
+
+## Step 3 — Write the feature doc
+
+Create `docs/features/<feature-name>.md` (use the feature name from $ARGUMENTS, kebab-cased). The doc must contain:
+
+1. **Overview** — one paragraph describing what the feature does and why
+2. **Design decisions** — key choices made and why (alternatives considered)
+3. **Security considerations** — how the feature meets the relevant security requirements
+4. **Implementation plan** — a numbered list of concrete implementation steps
+5. **Tasks** — do not add a task list to the feature doc. Instead, update `docs/tasks.md`:
+    - **Edit** tasks that need to change due to updated feature requirements
+    - **Check off** tasks that are already done
+    - **Add** tasks that are missing
+
+   Tasks must be grouped by *user-facing feature area* (not by layer like backend/frontend). Each task should be a single, testable unit of work.
+
+   Example task grouping: instead of "Backend: add endpoint, Frontend: add UI", group as "User can register a passkey: [ ] store credential, [ ] display registration flow, [ ] write integration test".
+
+## Step 4 — Implement
+
+Before writing any code, switch to a feature branch:
+
+```bash
+git checkout -b feat/<feature-name>
+```
+
+Do not commit on `main`.
+
+Work through the tasks in the feature doc one by one. For each task:
+- Mark it complete in the doc as you finish it
+- Write tests alongside the implementation (not after); tests must cover all positive paths, all negative paths, all branches, and common edge cases
+- Follow the conventions in `CLAUDE.md`
+
+Only implement what is specified in the requirements. Do not add features, extra configuration options, or unnecessary abstractions.
+
+## Step 5 — Test
+
+Run tests incrementally as you implement each layer. Do not defer testing to the end.
+
+### Type-check and lint (after every file change)
+
+After each file is written or modified, run the type-checker and linter for the affected layer:
+
+- **Frontend:** `bun run check` (svelte-check + TypeScript)
+- **Backend:** `./gradlew check` (ktlint + compilation)
+
+Fix every error and warning before moving on to the next task. Do not accumulate warnings to clean up later.
+
+### After backend changes
+
+Every time you finish a backend task (new endpoint, service change, etc.), run the backend unit and integration tests immediately:
+
+```bash
+cd backend && ./gradlew test
+```
+
+Scope to the changed package when iterating: `./gradlew test --tests "com.github.matthiasbalke.todo.<package>.*"`
+
+Fix all failures before moving on to the next task.
+
+### After frontend changes
+
+Every time you finish a frontend task (new component, store change, API call, etc.), run the frontend unit tests immediately:
+
+```bash
+cd frontend && bun run test --run
+```
+
+Fix all failures before moving on to the next task.
+
+### E2E tests (after the full feature is complete)
+
+Only run E2E tests once all backend and frontend unit tests pass. Use the project's full-stack test script, which builds Docker images, starts all services, and runs Playwright:
+
+```bash
+./run-e2e-tests.sh
+```
+
+Or manually:
+```bash
+docker compose up --build -d nginx
+cd e2e && bunx playwright test
+```
+
+If E2E tests fail, fix the issues. Do not consider the feature done until all three test suites pass.

--- a/backend/src/main/kotlin/com/github/matthiasbalke/todo/auth/SecurityConfig.kt
+++ b/backend/src/main/kotlin/com/github/matthiasbalke/todo/auth/SecurityConfig.kt
@@ -48,7 +48,19 @@ class SecurityConfig(
     @Bean
     fun corsConfigurationSource(): CorsConfigurationSource {
         val config = CorsConfiguration()
-        config.allowedOrigins = allowedOrigins.split(",").map { it.trim() }
+        val normalizedOrigins = mutableListOf<String>()
+        allowedOrigins.split(",").forEach { origin ->
+            val trimmed = origin.trim()
+            normalizedOrigins.add(trimmed)
+            // For default ports (443 for https, 80 for http), also accept the origin without port
+            // since browsers omit the port from the Origin header for default ports
+            if (trimmed.endsWith(":443") && trimmed.startsWith("https://")) {
+                normalizedOrigins.add(trimmed.substringBeforeLast(":443"))
+            } else if (trimmed.endsWith(":80") && trimmed.startsWith("http://")) {
+                normalizedOrigins.add(trimmed.substringBeforeLast(":80"))
+            }
+        }
+        config.allowedOrigins = normalizedOrigins
         config.allowedMethods = listOf(
             HttpMethod.GET.name(),
             HttpMethod.POST.name(),

--- a/backend/start-https-backend.sh
+++ b/backend/start-https-backend.sh
@@ -1,10 +1,18 @@
 #!/usr/bin/env bash
 
-DOMAIN=todo.example.com
-PORT=
+DOMAIN=${1:-todo.example.com}
+PORT=${2:-443}
 
-export CORS_ALLOWED_ORIGINS=https://${DOMAIN}${PORT}
-export WEBAUTHN_RP_ID=${DOMAIN}
+ADDRESS=https://${DOMAIN}:${PORT}
+
+echo Starting on "${ADDRESS}"
+echo ""
+
+CORS_ALLOWED_ORIGINS="${ADDRESS}"
+export CORS_ALLOWED_ORIGINS
+
+WEBAUTHN_RP_ID="${DOMAIN}"
+export WEBAUTHN_RP_ID
 
 ./gradlew compileKotlin --continuous --parallel --build-cache --configuration-cache &
 CONTINUOUS_PID=$!

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,8 @@ services:
       # this is set for e2e tests
       RATE_LIMIT_CAPACITY: 10000
       RATE_LIMIT_WINDOW_MINUTES: 1
+      CORS_ALLOWED_ORIGINS: http://localhost:5173
+      WEBAUTHN_RP_ID: localhost
     depends_on:
       postgres:
         condition: service_healthy

--- a/docs/howto-local-dev-https-setup.md
+++ b/docs/howto-local-dev-https-setup.md
@@ -51,6 +51,74 @@ The `.certs/` directory is already in `.gitignore` (Java/Kotlin/Node preset cove
 
 ## 3. Start the HTTPS Dev Server
 
+### Using the convenience scripts (recommended)
+
+Two wrapper scripts are provided to simplify starting both the backend and frontend with HTTPS and the correct environment variables:
+
+#### `frontend/start-https-frontend.sh`
+
+Starts the Vite dev server with HTTPS and configures HMR (Hot Module Reloading) for access via a domain or tunnel.
+
+**Usage:**
+
+```bash
+./frontend/start-https-frontend.sh [DOMAIN] [PORT]
+```
+
+**Parameters:**
+- `DOMAIN` (optional, default: `todo.example.com`) — the hostname/domain used to access the app (e.g., your LAN IP `192.168.1.42`, a tunnel domain like `todo.example.com`, or `localhost`)
+- `PORT` (optional, default: `443`) — the HTTPS port
+
+**Examples:**
+
+```bash
+# Direct LAN IP access (no HMR adjustment needed)
+./frontend/start-https-frontend.sh 192.168.1.42 5173
+
+# Tunnel/reverse proxy access (adjusts HMR to use the tunnel domain)
+./frontend/start-https-frontend.sh todo.example.com 443
+
+# localhost (uses defaults, but forwards HMR correctly if needed)
+./frontend/start-https-frontend.sh
+```
+
+The script sets `VITE_HMR_HOST` and `VITE_HMR_CLIENT_PORT` so Vite's Hot Module Reloading WebSocket connects to the correct endpoint instead of falling back to localhost.
+
+#### `backend/start-https-backend.sh`
+
+Starts the Spring Boot backend with HTTPS configuration and WebAuthn settings.
+
+**Usage:**
+
+```bash
+./backend/start-https-backend.sh [DOMAIN] [PORT]
+```
+
+**Parameters:**
+- `DOMAIN` (optional, default: `todo.example.com`) — the hostname/domain matching the frontend access (must match `WEBAUTHN_RP_ID`)
+- `PORT` (optional, default: `443`) — the HTTPS port
+
+**What it does:**
+1. Exports `WEBAUTHN_RP_ID` — the domain the browser sees when authenticating (must match exactly)
+2. Exports `CORS_ALLOWED_ORIGINS` — allows the frontend origin to make API requests
+3. Starts a continuous Gradle compilation watcher for hot reloading
+4. Runs the Spring Boot application with `./gradlew bootRun`
+
+**Examples:**
+
+```bash
+# Direct LAN IP access
+./backend/start-https-backend.sh 192.168.1.42 5173
+
+# Tunnel/reverse proxy access
+./backend/start-https-backend.sh todo.example.com 443
+
+# localhost
+./backend/start-https-backend.sh
+```
+
+### Manual approach
+
 A dedicated Vite config (`frontend/vite.config.https.ts`) is already committed. It extends the base config with HTTPS and `host: '0.0.0.0'` and reads the certs from `.certs/`.
 
 ```bash
@@ -59,7 +127,7 @@ cd frontend && bun run dev:https
 
 The dev server will now be reachable at `https://<MY_IP>:5173`.
 
-### HMR when accessing via a tunnel or reverse proxy
+#### HMR when accessing via a tunnel or reverse proxy
 
 If you access the dev server through a public tunnel (e.g. Cloudflare Tunnel at `https://todo.example.com`) instead of directly via the LAN IP, Vite derives the HMR WebSocket URL from the page's host. The tunnel typically doesn't forward that WebSocket back to Vite's port, so the browser logs a `WebSocket connection failed` error and falls back to `localhost:5173`. HMR still works via the fallback, but the error is noisy.
 
@@ -73,17 +141,15 @@ VITE_HMR_HOST=todo.example.com VITE_HMR_CLIENT_PORT=4443 bun run dev:https
 
 `VITE_HMR_CLIENT_PORT` defaults to `443`. When these vars are unset (normal LAN or localhost workflow) Vite's auto-detection applies unchanged.
 
-A convenience wrapper that sets both vars is committed at `frontend/start-https-frontend.sh`. Edit `VITE_HMR_HOST` there to match your tunnel domain, then run it instead of `bun run dev:https` directly.
-
 ---
 
 ## 4. Configure the Backend
 
-Set these environment variables when starting the backend (or add to a local `.env` / run config):
+When using the `start-https-backend.sh` script, environment variables are set automatically. If starting the backend manually, set these:
 
 ```bash
-WEBAUTHN_RP_ID=<MY_IP>
-CORS_ALLOWED_ORIGINS=https://<MY_IP>:5173
+WEBAUTHN_RP_ID=<MY_IP_OR_DOMAIN>
+CORS_ALLOWED_ORIGINS=https://<MY_IP_OR_DOMAIN>:5173
 ```
 
 Example for a shell session:
@@ -94,7 +160,7 @@ CORS_ALLOWED_ORIGINS=https://192.168.1.42:5173 \
 ./gradlew bootRun
 ```
 
-> **Note:** `WEBAUTHN_RP_ID` must exactly match the host part of the origin the browser sees. The browser will reject credentials if these don't match (you'll see the "Passkey origin not allowed" error added in the last fix).
+> **Note:** `WEBAUTHN_RP_ID` must exactly match the host part of the origin the browser sees. The browser will reject credentials if these don't match (you'll see the "Passkey origin not allowed" error).
 
 ---
 
@@ -207,7 +273,7 @@ Tap **Allow**.
 
 ---
 
-## 6. Install the Profile
+## 7. Install the Profile
 
 1. Open **Settings → General → VPN & Device Management**
 2. Under **Downloaded Profile**, tap the **mkcert** entry
@@ -216,7 +282,7 @@ Tap **Allow**.
 
 ---
 
-## 7. Enable Full Trust (Critical — easy to miss)
+## 8. Enable Full Trust (Critical — easy to miss)
 
 Installing the profile is not enough. You must also explicitly enable trust for TLS:
 
@@ -228,19 +294,43 @@ Without this step, Safari will show an "untrusted certificate" error and WebAuth
 
 ---
 
-## 8. Test
+## 9. Test
 
-1. Start the backend with the env vars from step 4
-2. Start the frontend dev server: `cd frontend && bun run dev`
+**Using the convenience scripts (recommended):**
+
+```bash
+# In one terminal, start the backend
+./backend/start-https-backend.sh 192.168.1.42 5173
+
+# In another terminal, start the frontend
+./frontend/start-https-frontend.sh 192.168.1.42 5173
+
+# On the iPhone, open Safari and navigate to https://192.168.1.42:5173
+```
+
+**Manual approach:**
+
+1. Start the backend with the env vars from section 4
+2. Start the frontend dev server: `cd frontend && bun run dev:https`
 3. On the iPhone, open Safari and navigate to `https://<MY_IP>:5173`
-4. The padlock should be green — if Safari shows a certificate warning, step 6 or 7 was missed
+4. The padlock should be green — if Safari shows a certificate warning, section 8 was missed
 5. Attempt passkey registration or login
 
 ---
 
 ## Reverting to Normal Dev
 
-Remove the `https` and `host` keys from `vite.config.ts` and restart without the env vars (defaults are `WEBAUTHN_RP_ID=localhost`, `CORS_ALLOWED_ORIGINS=http://localhost:5173`).
+Stop the scripts and revert to normal development:
+
+```bash
+# Frontend (in frontend/ directory)
+bun run dev
+
+# Backend
+./gradlew bootRun
+```
+
+This uses `WEBAUTHN_RP_ID=localhost` and `CORS_ALLOWED_ORIGINS=http://localhost:5173` by default.
 
 The iPhone profile can stay installed — it only affects connections to your dev machine's CA-signed certs and does not interfere with normal HTTPS browsing.
 
@@ -250,9 +340,10 @@ The iPhone profile can stay installed — it only affects connections to your de
 
 | Symptom | Likely cause |
 |---|---|
-| Safari shows "This Connection Is Not Private" | Step 7 (Certificate Trust Settings toggle) was skipped |
-| "Passkey origin not allowed — check the server configuration" | `WEBAUTHN_RP_ID` doesn't match the IP in the browser URL |
+| Safari shows "This Connection Is Not Private" | Section 8 (Certificate Trust Settings toggle) was skipped |
+| "Passkey origin not allowed — check the server configuration" | `WEBAUTHN_RP_ID` doesn't match the domain/IP in the browser URL |
 | CORS error in browser console | `CORS_ALLOWED_ORIGINS` doesn't match the exact origin (`https://<IP>:5173`) |
 | Certificate error on Mac too | Re-run `mkcert -install` after `brew install nss` |
 | IP changed after router reboot | Assign a static DHCP lease to your Mac, or regenerate the cert for the new IP |
-| `WebSocket connection to 'wss://…' failed` in console | Set `VITE_HMR_HOST` to the tunnel domain (see section 3) |
+| `WebSocket connection to 'wss://…' failed` in console | Set `VITE_HMR_HOST` to the correct domain/IP using `start-https-frontend.sh` |
+| Backend not starting | Make sure `WEBAUTHN_RP_ID` and `CORS_ALLOWED_ORIGINS` match exactly |

--- a/frontend/start-https-frontend.sh
+++ b/frontend/start-https-frontend.sh
@@ -1,9 +1,15 @@
 #!/usr/bin/env bash
 
-VITE_HMR_HOST=todo.example.com
+DOMAIN=${1:-todo.example.com}
+PORT=${2:-443}
+
+VITE_HMR_HOST=${DOMAIN}
 export VITE_HMR_HOST
 
-VITE_HMR_CLIENT_PORT=443
+VITE_HMR_CLIENT_PORT=${PORT}
 export VITE_HMR_CLIENT_PORT
 
-bun run dev:https
+echo Starting on https://${VITE_HMR_HOST}:${VITE_HMR_CLIENT_PORT}
+echo ""
+
+~/.bun/bin/bun run dev:https


### PR DESCRIPTION
When using HTTPS on port 443 (or HTTP on port 80), browsers omit the port from the Origin header per HTTP specification. The CORS configuration was expecting the explicit port, causing 'Invalid CORS request' errors.

Now the backend normalizes allowed origins to accept both forms:
- https://domain.com:443 (configured)
- https://domain.com (sent by browser)

Similarly for HTTP on port 80. This fixes auth failures when accessing the app via custom domains like todo-notebook.example.com on Windows.