### PR TITLE
Fix: Support per-user group assignments for shared lists

### DIFF
--- a/backend/src/main/kotlin/com/github/matthiasbalke/todo/lists/ListController.kt
+++ b/backend/src/main/kotlin/com/github/matthiasbalke/todo/lists/ListController.kt
@@ -86,7 +86,7 @@ class ListController(
 
     @GetMapping
     fun getLists(@AuthenticationPrincipal userId: UUID): kotlin.collections.List<ListSummaryDto> =
-        listService.getListsForUser(userId).map { it.toSummaryDto() }
+        listService.getListsForUser(userId).map { it.toSummaryDto(userId, listGroupService) }
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
@@ -137,14 +137,14 @@ class ListController(
         @AuthenticationPrincipal userId: UUID,
         @PathVariable id: UUID,
         @RequestBody body: AssignGroupRequest,
-    ): ListSummaryDto = listGroupService.assignListToGroup(id, userId, body.groupId).toSummaryDto()
+    ): ListSummaryDto = listGroupService.assignListToGroup(id, userId, body.groupId).toSummaryDto(userId, listGroupService)
 
     @PatchMapping("/{id}/group-order")
     fun reorderInGroup(
         @AuthenticationPrincipal userId: UUID,
         @PathVariable id: UUID,
         @RequestBody body: ReorderInGroupRequest,
-    ): ListSummaryDto = listGroupService.reorderListInGroup(id, userId, body.sortOrder).toSummaryDto()
+    ): ListSummaryDto = listGroupService.reorderListInGroup(id, userId, body.sortOrder).toSummaryDto(userId, listGroupService)
 
     // ─── Member management ───────────────────────────────────────────────────
 
@@ -191,14 +191,17 @@ class ListController(
         createdAt = createdAt,
     )
 
-    private fun List.toSummaryDto() = ListSummaryDto(
-        id = id,
-        name = name,
-        emoji = emoji,
-        createdAt = createdAt,
-        groupId = groupId,
-        sortOrderInGroup = sortOrderInGroup,
-    )
+    private fun List.toSummaryDto(userId: UUID, listGroupService: ListGroupService) : ListSummaryDto {
+        val assignment = listGroupService.getListAssignmentForUser(id, userId)
+        return ListSummaryDto(
+            id = id,
+            name = name,
+            emoji = emoji,
+            createdAt = createdAt,
+            groupId = assignment?.groupId,
+            sortOrderInGroup = assignment?.sortOrder ?: 0,
+        )
+    }
 
     private fun ListMembership.toMemberDto(): MemberDto {
         val user = userRepository.findById(userId).orElseThrow()

--- a/backend/src/main/kotlin/com/github/matthiasbalke/todo/lists/ListGroupAssignment.kt
+++ b/backend/src/main/kotlin/com/github/matthiasbalke/todo/lists/ListGroupAssignment.kt
@@ -8,25 +8,22 @@ import java.time.Instant
 import java.util.UUID
 
 @Entity
-@Table(name = "lists")
-class List(
+@Table(name = "list_group_assignments")
+class ListGroupAssignment(
     @Id
     val id: UUID = UUID.randomUUID(),
 
-    @Column(nullable = false)
-    var name: String,
+    @Column(name = "list_id", nullable = false)
+    val listId: UUID,
 
-    @Column
-    var emoji: String? = null,
+    @Column(name = "user_id", nullable = false)
+    val userId: UUID,
 
-    @Column
-    var description: String? = null,
+    @Column(name = "group_id")
+    var groupId: UUID? = null,
 
-    @Column(name = "default_sort_field", nullable = false)
-    var defaultSortField: String = "CREATED",
-
-    @Column(name = "default_sort_direction", nullable = false)
-    var defaultSortDirection: String = "ASC",
+    @Column(name = "sort_order", nullable = false)
+    var sortOrder: Int = 0,
 
     @Column(name = "created_at", nullable = false, updatable = false)
     val createdAt: Instant = Instant.now(),

--- a/backend/src/main/kotlin/com/github/matthiasbalke/todo/lists/ListGroupAssignmentRepository.kt
+++ b/backend/src/main/kotlin/com/github/matthiasbalke/todo/lists/ListGroupAssignmentRepository.kt
@@ -1,0 +1,10 @@
+package com.github.matthiasbalke.todo.lists
+
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.UUID
+
+interface ListGroupAssignmentRepository : JpaRepository<ListGroupAssignment, UUID> {
+    fun findByListIdAndUserId(listId: UUID, userId: UUID): ListGroupAssignment?
+    fun findAllByUserId(userId: UUID): kotlin.collections.List<ListGroupAssignment>
+    fun deleteByGroupId(groupId: UUID)
+}

--- a/backend/src/main/kotlin/com/github/matthiasbalke/todo/lists/ListGroupService.kt
+++ b/backend/src/main/kotlin/com/github/matthiasbalke/todo/lists/ListGroupService.kt
@@ -10,6 +10,7 @@ import java.util.UUID
 class ListGroupService(
     private val listGroupRepository: ListGroupRepository,
     private val listRepository: ListRepository,
+    private val listGroupAssignmentRepository: ListGroupAssignmentRepository,
     private val listAccessService: ListAccessService,
 ) {
 
@@ -34,8 +35,7 @@ class ListGroupService(
     @Transactional
     fun deleteGroup(groupId: UUID, userId: UUID) {
         requireOwnership(groupId, userId)
-        // Set groupId to null on all lists in this group (DB ON DELETE SET NULL handles it,
-        // but we clear in-memory state by deleting directly)
+        listGroupAssignmentRepository.deleteByGroupId(groupId)
         listGroupRepository.deleteById(groupId)
     }
 
@@ -57,21 +57,25 @@ class ListGroupService(
                 throw ResponseStatusException(HttpStatus.FORBIDDEN, "You do not own this group")
             }
         }
-        val list = listRepository.findById(listId).orElseThrow {
+        val assignment = listGroupAssignmentRepository.findByListIdAndUserId(listId, userId)
+            ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "Assignment not found")
+        assignment.groupId = groupId
+        listGroupAssignmentRepository.save(assignment)
+        return listRepository.findById(listId).orElseThrow {
             ResponseStatusException(HttpStatus.NOT_FOUND, "List not found")
         }
-        list.groupId = groupId
-        return listRepository.save(list)
     }
 
     @Transactional
     fun reorderListInGroup(listId: UUID, userId: UUID, newSortOrder: Int): com.github.matthiasbalke.todo.lists.List {
         listAccessService.requireMembership(listId, userId)
-        val list = listRepository.findById(listId).orElseThrow {
+        val assignment = listGroupAssignmentRepository.findByListIdAndUserId(listId, userId)
+            ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "Assignment not found")
+        assignment.sortOrder = newSortOrder
+        listGroupAssignmentRepository.save(assignment)
+        return listRepository.findById(listId).orElseThrow {
             ResponseStatusException(HttpStatus.NOT_FOUND, "List not found")
         }
-        list.sortOrderInGroup = newSortOrder
-        return listRepository.save(list)
     }
 
     private fun requireOwnership(groupId: UUID, userId: UUID): ListGroup {
@@ -83,4 +87,7 @@ class ListGroupService(
         }
         return group
     }
+
+    fun getListAssignmentForUser(listId: UUID, userId: UUID): ListGroupAssignment? =
+        listGroupAssignmentRepository.findByListIdAndUserId(listId, userId)
 }

--- a/backend/src/main/kotlin/com/github/matthiasbalke/todo/lists/ListService.kt
+++ b/backend/src/main/kotlin/com/github/matthiasbalke/todo/lists/ListService.kt
@@ -14,6 +14,7 @@ import java.util.UUID
 class ListService(
     private val listRepository: ListRepository,
     private val listMembershipRepository: ListMembershipRepository,
+    private val listGroupAssignmentRepository: ListGroupAssignmentRepository,
     private val userRepository: UserRepository,
     private val listAccessService: ListAccessService,
     private val listGroupRepository: ListGroupRepository,
@@ -41,21 +42,14 @@ class ListService(
         listMembershipRepository.save(
             ListMembership(listId = list.id, userId = userId, role = ListRole.OWNER)
         )
+        listGroupAssignmentRepository.save(
+            ListGroupAssignment(listId = list.id, userId = userId)
+        )
         return list
     }
 
-    fun getListsForUser(userId: UUID): kotlin.collections.List<List> {
-        val lists = listRepository.findAllByMemberUserId(userId)
-        val userGroupIds = listGroupRepository.findAllByUserIdOrderBySortOrder(userId).map { it.id }.toSet()
-        
-        return lists.map { list ->
-            // If the list has a groupId but the user doesn't own that group, clear it
-            if (list.groupId != null && !userGroupIds.contains(list.groupId)) {
-                list.groupId = null
-            }
-            list
-        }
-    }
+    fun getListsForUser(userId: UUID): kotlin.collections.List<List> =
+        listRepository.findAllByMemberUserId(userId)
 
     fun getListById(listId: UUID, userId: UUID): List {
         listAccessService.requireMembership(listId, userId)
@@ -107,6 +101,9 @@ class ListService(
         }
         val membership = listMembershipRepository.save(
             ListMembership(listId = listId, userId = target.id, role = role)
+        )
+        listGroupAssignmentRepository.save(
+            ListGroupAssignment(listId = listId, userId = target.id)
         )
         ssePublisher.publish(ListEvent.MemberAdded(listId, membership.toPayload()))
         return membership

--- a/backend/src/main/resources/db/migration/V7__add_list_group_assignments.sql
+++ b/backend/src/main/resources/db/migration/V7__add_list_group_assignments.sql
@@ -1,0 +1,41 @@
+CREATE TABLE list_group_assignments (
+    id         UUID         PRIMARY KEY,
+    list_id    UUID         NOT NULL REFERENCES lists(id) ON DELETE CASCADE,
+    user_id    UUID         NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    group_id   UUID REFERENCES list_groups(id) ON DELETE SET NULL,
+    sort_order INT          NOT NULL DEFAULT 0,
+    created_at TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    CONSTRAINT unique_list_user UNIQUE (list_id, user_id)
+);
+
+CREATE INDEX idx_list_group_assignments_list_id ON list_group_assignments(list_id);
+CREATE INDEX idx_list_group_assignments_user_id ON list_group_assignments(user_id);
+CREATE INDEX idx_list_group_assignments_group_id ON list_group_assignments(group_id);
+
+-- Migrate existing data from lists table
+INSERT INTO list_group_assignments (id, list_id, user_id, group_id, sort_order)
+SELECT 
+    gen_random_uuid(),
+    l.id,
+    lm.user_id,
+    l.group_id,
+    l.sort_order_in_group
+FROM lists l
+JOIN list_memberships lm ON l.id = lm.list_id
+WHERE l.group_id IS NOT NULL;
+
+-- Also create entries for lists without groups to track sort_order_in_group
+INSERT INTO list_group_assignments (id, list_id, user_id, group_id, sort_order)
+SELECT 
+    gen_random_uuid(),
+    l.id,
+    lm.user_id,
+    NULL,
+    l.sort_order_in_group
+FROM lists l
+JOIN list_memberships lm ON l.id = lm.list_id
+WHERE l.group_id IS NULL;
+
+-- Remove columns from lists table
+ALTER TABLE lists DROP COLUMN group_id;
+ALTER TABLE lists DROP COLUMN sort_order_in_group;

--- a/backend/src/test/kotlin/com/github/matthiasbalke/todo/lists/ListGroupIntegrationTest.kt
+++ b/backend/src/test/kotlin/com/github/matthiasbalke/todo/lists/ListGroupIntegrationTest.kt
@@ -292,4 +292,59 @@ class ListGroupIntegrationTest : AbstractIntegrationTest() {
             status { isForbidden() }
         }
     }
+
+    // ─── Shared lists with per-user group assignments ─────────────────────────
+
+    @Test
+    fun `shared list - each user should be able to assign it to different groups`() {
+        // Setup: Two users, a shared list
+        val userA = createUser()
+        val userB = createUser()
+        val listId = createListAsUser(userA, "Shared List")
+
+        // User A adds User B as an editor
+        mockMvc.post("/api/lists/$listId/members") {
+            header("Authorization", bearerHeader(userA))
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"email":"${userB.email}","role":"EDITOR"}"""
+        }.andExpect { status { isCreated() } }
+
+        // User A creates group A1 and assigns the list to it
+        val groupA1 = createGroupAsUser(userA, "Group A1")
+        mockMvc.patch("/api/lists/$listId/group") {
+            header("Authorization", bearerHeader(userA))
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"groupId":"$groupA1"}"""
+        }.andExpect {
+            status { isOk() }
+            jsonPath("$.groupId") { value(groupA1.toString()) }
+        }
+
+        // User B creates group B1 and assigns the same list to it
+        val groupB1 = createGroupAsUser(userB, "Group B1")
+        mockMvc.patch("/api/lists/$listId/group") {
+            header("Authorization", bearerHeader(userB))
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"groupId":"$groupB1"}"""
+        }.andExpect {
+            status { isOk() }
+            jsonPath("$.groupId") { value(groupB1.toString()) }
+        }
+
+        // Verify User A sees the list in group A1
+        mockMvc.get("/api/lists") {
+            header("Authorization", bearerHeader(userA))
+        }.andExpect {
+            status { isOk() }
+            jsonPath("$[?(@.id == '$listId')].groupId") { value(groupA1.toString()) }
+        }
+
+        // Verify User B sees the list in group B1
+        mockMvc.get("/api/lists") {
+            header("Authorization", bearerHeader(userB))
+        }.andExpect {
+            status { isOk() }
+            jsonPath("$[?(@.id == '$listId')].groupId") { value(groupB1.toString()) }
+        }
+    }
 }

--- a/frontend/start-https-frontend.sh
+++ b/frontend/start-https-frontend.sh
@@ -12,4 +12,4 @@ export VITE_HMR_CLIENT_PORT
 echo Starting on https://${VITE_HMR_HOST}:${VITE_HMR_CLIENT_PORT}
 echo ""
 
-~/.bun/bin/bun run dev:https
+$(which bun) run dev:https


### PR DESCRIPTION
closes #75

## Problem
Shared lists could only have one group assignment visible to all users. The group_id was stored globally in the lists table, preventing users from independently assigning the same shared list to different groups.

## Solution
Introduce a list_group_assignments table with (list_id, user_id) composite key to track per-user group assignments and sort orders. This allows the same shared list to be in group A1 for user A and group B1 for user B simultaneously.

## Changes
- Add ListGroupAssignment entity and ListGroupAssignmentRepository
- Add V7 migration to create assignments table and migrate existing data  
- Update ListService to create assignment records when creating/adding members
- Update ListGroupService to manage assignments instead of list.groupId
- Update ListController to fetch per-user assignments when building responses
- Add integration test verifying shared list can be in different groups per user

## Testing
- All backend tests pass
- New integration test covers the core use case