### PR TITLE
configure PWA to start with /lists

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -38,7 +38,7 @@ export default defineConfig({
         name: 'Todo',
         short_name: 'Todo',
         display: 'standalone',
-        start_url: '/',
+        start_url: '/lists',
         theme_color: '#ffffff',
         background_color: '#ffffff',
         icons: [


### PR DESCRIPTION
The PWA always starts with `/` which in turn redirects to `/auth`. Maybe this is the reason, that one always has to reauthenticate all the time.